### PR TITLE
V1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.5.0 (2024-03-21)
 
 - Added trailing comma support in object and array literals. For example, `{{ obj = { key: "value", } }}` and `{{ arr = [1, 2, 3, ] }}` are now valid
+- Added support for comment with `{{-- --}}` syntax. For example, `{{-- This is a comment --}}`
 
 ## v1.4.1 (2024-03-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## v1.5.0 (2024-03-19)
+## v1.5.0 (2024-03-21)
 
 - Added trailing comma support in object and array literals. For example, `{{ obj = { key: "value", } }}` and `{{ arr = [1, 2, 3, ] }}` are now valid
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v1.5.0 (2024-03-19)
+
+- Added trailing comma support in object and array literals. For example, `{{ obj = { key: "value", } }}` and `{{ arr = [1, 2, 3, ] }}` are now valid
+
 ## v1.4.1 (2024-03-18)
 
 - Added link to a [Textwire VSCode extension link](https://marketplace.visualstudio.com/items?itemName=SerhiiCho.textwire) in the README.md file

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Textwire. A templating language for Go.
+# Textwire. A templating language for Go
 
 <p align="center">
 <a href="https://github.com/textwire/textwire/actions/workflows/go.yml"><img src="https://github.com/textwire/textwire/actions/workflows/go.yml/badge.svg"></a>

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -394,7 +394,7 @@ func TestEvalObjectLiteral(t *testing.T) {
 		{`{{ o = {"name": "John", "age": 22}; o.age }}`, "22"},
 		{`{{ user = {"father": {"name": "John"}}; user.father.name }}`, "John"},
 		{`{{ user = {"father": {"name": {"first": "Sam"}}}; user.father.name.first }}`, "Sam"},
-		{`{{ u = {"father": {name: {"first": "Sam"}}}; u['father']['name'].first }}`, "Sam"},
+		{`{{ u = {"father": {name: {"first": "Sam",},},}; u['father']['name'].first }}`, "Sam"},
 		{`{{ name = "Sam"; age = 12; obj = { name, age }; obj.name }}`, "Sam"},
 		{`{{ name = "Sam"; age = 12; obj = { name, age }; obj.age }}`, "12"},
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -403,3 +403,18 @@ func TestEvalObjectLiteral(t *testing.T) {
 		evaluationExpected(t, tt.inp, tt.expected)
 	}
 }
+
+func TestEvalComments(t *testing.T) {
+	tests := []struct {
+		inp      string
+		expected string
+	}{
+		{"{{-- This is a comment --}}", ""},
+		{"<section>{{-- This is a comment --}}</section>", "<section></section>"},
+		{"Some {{-- --}}text", "Some text"},
+	}
+
+	for _, tt := range tests {
+		evaluationExpected(t, tt.inp, tt.expected)
+	}
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -57,7 +57,14 @@ func (l *Lexer) NextToken() token.Token {
 	}
 
 	if l.char == '{' && l.peekChar() == '{' {
-		return l.bracesToken(token.LBRACES, "{{")
+		tok := l.bracesToken(token.LBRACES, "{{")
+
+		if l.char == '-' && l.peekChar() == '-' {
+			l.skipComment()
+			return l.NextToken()
+		}
+
+		return tok
 	}
 
 	if l.char == '}' && l.peekChar() == '}' && l.countCurlyBraces == 0 {
@@ -434,6 +441,17 @@ func (l *Lexer) skipWhitespace() {
 
 		l.advanceChar()
 	}
+}
+
+func (l *Lexer) skipComment() {
+	for l.char != '}' || l.peekChar() != '}' {
+		l.advanceChar()
+	}
+
+	l.isHTML = true
+
+	l.advanceChar() // skip "}"
+	l.advanceChar() // skip "}"
 }
 
 func (l *Lexer) peekChar() byte {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -481,3 +481,14 @@ func TestComponentDirective(t *testing.T) {
 		{Type: token.EOF, Literal: ""},
 	})
 }
+
+// Comments should be ignored by the lexer
+func TestCommentStatement(t *testing.T) {
+	inp := `<div>{{-- This is a comment --}}</div>`
+
+	TokenizeString(t, inp, []token.Token{
+		{Type: token.HTML, Literal: "<div>"},
+		{Type: token.HTML, Literal: "</div>"},
+		{Type: token.EOF, Literal: ""},
+	})
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -925,8 +925,14 @@ func (p *Parser) parseExpressionList(endTok token.TokenType) []ast.Expression {
 	result = append(result, p.parseExpression(LOWEST))
 
 	for p.peekTokenIs(token.COMMA) {
+		p.nextToken() // move to ","
+
+		// break when has a trailing comma
+		if p.peekTokenIs(endTok) {
+			break
+		}
+
 		p.nextToken() // skip ","
-		p.nextToken() // skip expression
 		result = append(result, p.parseExpression(LOWEST))
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -946,10 +946,6 @@ func TestParseArray(t *testing.T) {
 	if !testIntegerLiteral(t, arr.Elements[1], 234) {
 		return
 	}
-
-	if arr.String() != "[11, 234]" {
-		t.Errorf("arr.String() is not '[11, 234]', got %s", arr.String())
-	}
 }
 
 func TestParseIndexExp(t *testing.T) {
@@ -1289,12 +1285,6 @@ func TestParseObjectWithShorthandPropertyNotation(t *testing.T) {
 
 	if len(obj.Pairs) != 2 {
 		t.Fatalf("len(obj.Pairs) is not 2, got %d", len(obj.Pairs))
-	}
-
-	str := obj.String()
-
-	if str != `{"name": name, "age": age}` {
-		t.Fatalf(`obj.String() is not '{"name": name, "age": age}', got '%s'`, str)
 	}
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -920,7 +920,7 @@ func TestInsertStmt(t *testing.T) {
 }
 
 func TestParseArray(t *testing.T) {
-	inp := `{{ [11, 234] }}`
+	inp := `{{ [11, 234,] }}`
 
 	stmts := parseStatements(t, inp, 1, nil)
 	stmt, ok := stmts[0].(*ast.ExpressionStmt)
@@ -1237,7 +1237,7 @@ func TestParseEachElseStatement(t *testing.T) {
 }
 
 func TestParseObjectStatement(t *testing.T) {
-	inp := `{{ {"father": {name: "John"}} }}`
+	inp := `{{ {"father": {name: "John"},} }}`
 
 	stmts := parseStatements(t, inp, 1, nil)
 	stmt, ok := stmts[0].(*ast.ExpressionStmt)


### PR DESCRIPTION
- Added trailing comma support in object and array literals. For example, `{{ obj = { key: "value", } }}` and `{{ arr = [1, 2, 3, ] }}` are now valid
- Added support for comment with `{{-- --}}` syntax. For example, `{{-- This is a comment --}}`