### PR TITLE
fix: remove escaping " and ' in a printing string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v1.5.1 (2024-03-21)
+
+- Removed escaping single and double quotes in strings when printing them. For example, `{{ "Hello, 'world'" }}` and `{{ 'Hello, "world"' }}` will now print `Hello, 'world'` and `Hello, "world"` respectively instead of using HTML entities to escape the quotes
+
 ## v1.5.0 (2024-03-21)
 
 - Added trailing comma support in object and array literals. For example, `{{ obj = { key: "value", } }}` and `{{ arr = [1, 2, 3, ] }}` are now valid

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -74,7 +74,7 @@ func (e *Evaluator) Eval(node ast.Node, env *object.Env) object.Object {
 	case *ast.FloatLiteral:
 		return &object.Float{Value: node.Value}
 	case *ast.StringLiteral:
-		return &object.Str{Value: html.EscapeString(node.Value)}
+		return e.evalString(node, env)
 	case *ast.BooleanLiteral:
 		return nativeBoolToBooleanObject(node.Value)
 	case *ast.ObjectLiteral:
@@ -511,6 +511,16 @@ func (e *Evaluator) evalDotExp(node *ast.DotExp, env *object.Env) object.Object 
 	key := node.Key.(*ast.Identifier)
 
 	return e.evalObjectIndexExp(left.(*object.Obj), key.Value, node)
+}
+
+func (e *Evaluator) evalString(node *ast.StringLiteral, _ *object.Env) object.Object {
+	str := html.EscapeString(node.Value)
+
+	// unescape single and double quotes
+	str = strings.ReplaceAll(str, "&#34;", `"`)
+	str = strings.ReplaceAll(str, "&#39;", `'`)
+
+	return &object.Str{Value: str}
 }
 
 func (e *Evaluator) evalPrefixExp(node *ast.PrefixExp, env *object.Env) object.Object {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -163,7 +163,9 @@ func TestEvalStringExp(t *testing.T) {
 		expected string
 	}{
 		{`{{ "Hello World" }}`, "Hello World"},
-		{`{{ "She \"is\" pretty" }}`, `She &#34;is&#34; pretty`},
+		{`<div {{ 'data-attr="Test"' }}></div>`, `<div data-attr="Test"></div>`},
+		{`<div {{ "data-attr='Test'" }}></div>`, `<div data-attr='Test'></div>`},
+		{`{{ "She \"is\" pretty" }}`, `She "is" pretty`},
 		{`{{ "Korotchaeva" + " " + "Anna" }}`, "Korotchaeva Anna"},
 		{`{{ "She" + " " + "is" + " " + "nice" }}`, "She is nice"},
 		{"{{ '' }}", ""},


### PR DESCRIPTION
- Removed escaping single and double quotes in strings when printing them. For example, `{{ "Hello, 'world'" }}` and `{{ 'Hello, "world"' }}` will now print `Hello, 'world'` and `Hello, "world"` respectively instead of using HTML entities to escape the quotes