### PR TITLE
V1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v1.5.2 (2024-03-22)
 
-- Fixed bug where you were you couldn't comment a block of Textwire code
+- Fixed a bug where you were you couldn't comment a block of Textwire code
+- Added error check when executing `@each` statement. Occasionally, if passed array was invalid, it would panic. Now, it will return an error message
 
 ## v1.5.1 (2024-03-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v1.5.2 (2024-03-22)
+
+- Fixed bug where you were you couldn't comment a block of Textwire code
+
 ## v1.5.1 (2024-03-21)
 
 - Removed escaping single and double quotes in strings when printing them. For example, `{{ "Hello, 'world'" }}` and `{{ 'Hello, "world"' }}` will now print `Hello, 'world'` and `Hello, "world"` respectively instead of using HTML entities to escape the quotes

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -351,6 +351,10 @@ func (e *Evaluator) evalEachStmt(node *ast.EachStmt, env *object.Env) object.Obj
 	varName := node.Var.Value
 	arrObj := e.Eval(node.Array, newEnv)
 
+	if isError(arrObj) {
+		return arrObj
+	}
+
 	elems := arrObj.(*object.Array).Elements
 	elemsLen := len(elems)
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -414,6 +414,7 @@ func TestEvalComments(t *testing.T) {
 		{"{{-- This is a comment --}}", ""},
 		{"<section>{{-- This is a comment --}}</section>", "<section></section>"},
 		{"Some {{-- --}}text", "Some text"},
+		{"{{-- @each(u in users){{ u }}@end --}}", ""},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -445,16 +445,17 @@ func (l *Lexer) skipWhitespace() {
 
 func (l *Lexer) skipComment() {
 	for {
-		if l.char == '-' && l.peekChar() == '-' {
-			l.advanceChar() // skip "-"
-			l.advanceChar() // skip "-"
-
-			if l.char == '}' || l.peekChar() == '}' {
-				break
-			}
+		if l.char != '-' || l.peekChar() != '-' {
+			l.advanceChar()
+			continue
 		}
 
-		l.advanceChar()
+		l.advanceChar() // skip "-"
+		l.advanceChar() // skip "-"
+
+		if l.char == '}' || l.peekChar() == '}' {
+			break
+		}
 	}
 
 	l.isHTML = true

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -444,7 +444,16 @@ func (l *Lexer) skipWhitespace() {
 }
 
 func (l *Lexer) skipComment() {
-	for l.char != '}' || l.peekChar() != '}' {
+	for {
+		if l.char == '-' && l.peekChar() == '-' {
+			l.advanceChar() // skip "-"
+			l.advanceChar() // skip "-"
+
+			if l.char == '}' || l.peekChar() == '}' {
+				break
+			}
+		}
+
 		l.advanceChar()
 	}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -484,11 +484,21 @@ func TestComponentDirective(t *testing.T) {
 
 // Comments should be ignored by the lexer
 func TestCommentStatement(t *testing.T) {
-	inp := `<div>{{-- This is a comment --}}</div>`
+	t.Run("Simple comment", func(tt *testing.T) {
+		inp := `<div>{{-- This is a comment --}}</div>`
 
-	TokenizeString(t, inp, []token.Token{
-		{Type: token.HTML, Literal: "<div>"},
-		{Type: token.HTML, Literal: "</div>"},
-		{Type: token.EOF, Literal: ""},
+		TokenizeString(t, inp, []token.Token{
+			{Type: token.HTML, Literal: "<div>"},
+			{Type: token.HTML, Literal: "</div>"},
+			{Type: token.EOF, Literal: ""},
+		})
+	})
+
+	t.Run("Commented code", func(tt *testing.T) {
+		inp := `{{-- @each(u in users){{ u }}@end --}}`
+
+		TokenizeString(t, inp, []token.Token{
+			{Type: token.EOF, Literal: ""},
+		})
 	})
 }


### PR DESCRIPTION
- Fixed a bug where you were you couldn't comment a block of Textwire code
- Added error check when executing `@each` statement. Occasionally, if passed array was invalid, it would panic. Now, it will return an error message