### PR TITLE
V1.6.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22, 1.23]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,20 @@
 # Release notes
 
 ## v1.5.2 (2024-03-22)
-
 - Fixed a bug where you were you couldn't comment a block of Textwire code
 - Added error check when executing `@each` statement. Occasionally, if passed array was invalid, it would panic. Now, it will return an error message
 
 ## v1.5.1 (2024-03-21)
-
 - Removed escaping single and double quotes in strings when printing them. For example, `{{ "Hello, 'world'" }}` and `{{ 'Hello, "world"' }}` will now print `Hello, 'world'` and `Hello, "world"` respectively instead of using HTML entities to escape the quotes
 
 ## v1.5.0 (2024-03-21)
-
 - Added trailing comma support in object and array literals. For example, `{{ obj = { key: "value", } }}` and `{{ arr = [1, 2, 3, ] }}` are now valid
 - Added support for comment with `{{-- --}}` syntax. For example, `{{-- This is a comment --}}`
 
 ## v1.4.1 (2024-03-18)
-
 - Added link to a [Textwire VSCode extension link](https://marketplace.visualstudio.com/items?itemName=SerhiiCho.textwire) in the README.md file
 
 ## v1.4.0 (2024-03-11)
-
 - Added `@component` directive for creating reusable components
 - Simplified parsing logic for `@use`, `@insert` and `@reserve` directives
 - Added ability to put `@use`, `@insert` and `@reserve` directives inside any other directive like `@if`, `@each`, `@for`, `@component` etc. Previously, you could only put them at the top level of the template
@@ -28,22 +23,18 @@
 - Changed so that `@use` statement is not required to be the first in the file. Now, you can place it anywhere in the file
 
 ## v1.3.0 (2024-03-04)
-
 - Added `@breakIf` and `@continueIf` directives for the `@each` loop
 - Added `@breakIf` and `@continueIf` directives for the `@for` loop
 
 ## v1.2.0 (2024-03-02)
-
 - Added `@break` and `@continue` directives for the `@each` loop
 - Added `@break` and `@continue` directives for the `@for` loop
 - Fixed bug where you couldn't compare strings with the `==` operator. For example, `@if(n == "hello")` was returning error
 
 ## v1.1.0 (2024-02-28)
-
 - Added `@else` directive for the `@each` loop which will be executed if the loop has no items to iterate over
 - Added `@else` directive for the `@for` loop which will be executed if the loop has no items to iterate over
 - Code refactoring and naming improvements
 
 ## v1.0.0 (2024-02-26)
-
 - Initial release of the first stable version with support for all [the features](https://textwire.github.io/1.x/language-elements/) that we wanted to have in the 1.0.0 version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v1.6.0 (2024-08-23)
+- Improve error handling for functions. If you call a function that doesn't exist, it will not only tell that function doesn't exist, but also the type of the target that you are trying to call a function on
+- Added `join` function to arrays. For example, `{{ arr = [1, 2, 3]; arr.join(", ") }}` will print `1, 2, 3`
+
 ## v1.5.2 (2024-03-22)
 - Fixed a bug where you were you couldn't comment a block of Textwire code
 - Added error check when executing `@each` statement. Occasionally, if passed array was invalid, it would panic. Now, it will return an error message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## v1.6.0 (2024-08-23)
+## v1.6.0 (2024-08-22)
 - Improve error handling for functions. If you call a function that doesn't exist, it will not only tell that function doesn't exist, but also the type of the target that you are trying to call a function on
 - Added `join` function to arrays. For example, `{{ arr = [1, 2, 3]; arr.join(", ") }}` will print `1, 2, 3`
 

--- a/evaluator/array_functions.go
+++ b/evaluator/array_functions.go
@@ -7,3 +7,20 @@ func arrayLenFunc(receiver object.Object, args ...object.Object) object.Object {
 	length := len(receiver.(*object.Array).Elements)
 	return &object.Int{Value: int64(length)}
 }
+
+// arrayJoinFunc joins the elements of the given array with the given separator
+func arrayJoinFunc(receiver object.Object, args ...object.Object) object.Object {
+	separator := args[0].(*object.Str).Value
+	elements := receiver.(*object.Array).Elements
+
+	var result string
+
+	for i, el := range elements {
+		if i > 0 {
+			result += separator
+		}
+		result += el.String()
+	}
+
+	return &object.Str{Value: result}
+}

--- a/evaluator/array_functions_test.go
+++ b/evaluator/array_functions_test.go
@@ -10,6 +10,8 @@ func TestEvalArrayFunctions(t *testing.T) {
 		{`{{ [].len() }}`, "0"},
 		{`{{ [1, 2, 3].len() }}`, "3"},
 		{`{{ [0, [2, [1, 2]]].len() }}`, "2"},
+		{`{{ [1, 2, 3].join(", ") }}`, "1, 2, 3"},
+		{`{{ ["one", "two", "three"].join(" ") }}`, "one two three"},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -671,7 +671,7 @@ func (e *Evaluator) evalCallExp(
 		return buitin.Fn(receiverObj, args...)
 	}
 
-	return e.newError(node, fail.ErrFuncDoNotExist, node.Function.Value)
+	return e.newError(node, fail.ErrNoFuncForThisType, node.Function.Value, receiverObj.Type())
 }
 
 func (e *Evaluator) evalPostfixOperatorExp(

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -12,7 +12,8 @@ var functions = map[object.ObjectType]map[string]*object.Builtin{
 		"trim":  {Fn: strTrimFunc},
 	},
 	object.ARR_OBJ: {
-		"len": {Fn: arrayLenFunc},
+		"len":  {Fn: arrayLenFunc},
+		"join": {Fn: arrayJoinFunc},
 	},
 	object.FLOAT_OBJ: {
 		"int": {Fn: floatIntFunc},

--- a/fail/fail.go
+++ b/fail/fail.go
@@ -30,7 +30,6 @@ const (
 	ErrUnknownTypeForOperator  = "unknown type '%s' for '%s' operator"
 	ErrPrefixOperatorIsWrong   = "prefix operator '%s' cannot be applied to '%s'"
 	ErrUseStmtMustHaveProgram  = "the 'use' statement must have a program attached"
-	ErrFuncDoNotExist          = "function '%s' doesn't exist. Try to update the Textwire to the latest version or checkout the documentation https://textwire.github.io"
 	ErrNoFuncForThisType       = "function '%s' doesn't exist for type '%s'"
 	ErrLoopVariableIsReserved  = "the 'loop' variable is reserved. You cannot use it as a variable name"
 	ErrVariableTypeMismatch    = "cannot assign variable '%s' of type '%s' to type '%s'"


### PR DESCRIPTION
- Improve error handling for functions. If you call a function that doesn't exist, it will not only tell that function doesn't exist, but also the type of the target that you are trying to call a function on
- Added `join` function to arrays. For example, `{{ arr = [1, 2, 3]; arr.join(", ") }}` will print `1, 2, 3`