### PR TITLE
V2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * ♻️ - Refactoring code
 * 📝 - Adding or updating documentation
 
+## v2.1.1 (2024-10-24)
+- 🐛 Fixed bug where you couldn't pass `nil` to `textwire.NewTemplate` function
+
 ## v2.1.0 (2024-10-24)
 For more detailed information about this release, read the [Textwire v2.1.0 Release Notes](https://textwire.github.io/blog/2024/10/24/textwire-v2.1.0-release-notes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ For more detailed information about this release, read the [Textwire v2.1.0 Rele
 
 ## v2.0.0 (2024-10-18)
 - ♻️ [BREAKING CHANGE!] Moved `textwire.Config` to a separate package `config.Config`
-- ✨ Added the ability to register your own custom functions for specific types and use them in your Textwire code like built-in functions. If you are upgrading from version 1, make these changes:
+- ✨ [suggested by @joeyjurjens](https://github.com/joeyjurjens) Added the ability to register your own custom functions for specific types and use them in your Textwire code like built-in functions. If you are upgrading from version 1, make these changes:
     1. Change all the imports from `github.com/textwire/textwire` to `github.com/textwire/textwire/v2`
     2. Run `go mod tidy` to update the dependencies
     3. Change the package name from `textwire.Config` to `config.Config` in your code if you use configuration and import `"github.com/textwire/textwire/v2/config"`. If you already have a package named `config`, you can alias the import like `twconfig "github.com/textwire/textwire/v2/config"`

--- a/example/main.go
+++ b/example/main.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/textwire/textwire/v2"
-	"github.com/textwire/textwire/v2/config"
 )
 
 var tpl *textwire.Template
@@ -24,9 +23,7 @@ func main() {
 		return string(runes)
 	})
 
-	tpl, err = textwire.NewTemplate(&config.Config{
-		TemplateDir: "templates",
-	})
+	tpl, err = textwire.NewTemplate(nil)
 
 	if err != nil {
 		log.Fatal(err)

--- a/parsing.go
+++ b/parsing.go
@@ -123,6 +123,10 @@ func applyComponentToProgram(prog *ast.Program, progFilePath string) *fail.Error
 func applyOptions(opt *config.Config) {
 	usesTemplates = true
 
+	if opt == nil {
+		return
+	}
+
 	if opt.TemplateDir != "" {
 		conf.TemplateDir = strings.Trim(opt.TemplateDir, "/")
 	}


### PR DESCRIPTION
- 🐛 Fixed bug where you couldn't pass `nil` to `textwire.NewTemplate` function