### PR TITLE
V2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - 🐛 Fixing bugs
 - ♻️ Refactoring code
 
+## v2.4.0 (2025-01-08)
+
 ## v2.3.0 (2024-12-29)
 - 🐛 Fixed bugs with function `len` for `STRING` type that was not handling Unicode correctly
 - ✨ Added function `at` for `STRING` type that returns the character at the specified index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - 🐛 Fixing bugs
 - ♻️ Refactoring code
 
-## v2.4.0 (2025-01-11)
-- ✨ Added new functions for strings: `trimRight`, `trimLeft`, `repeat`
+## v2.4.0 (2025-01-19)
+- ✨ Added 3 new functions for strings: `trimRight`, `trimLeft`, `repeat`
 - ✨ Added shortcut for using components, instead of writing `@component("components/post-card", { post })` you can now write `@component("~post-card", { post })`. `~` is an alias for the `components/` directory
 - ✨ Added `@dump` directive to dump the value of a variable to the output. This is useful for debugging purposes
 - ✨ Added `2` new functions for arrays: `append` and `prepend` to add elements to the end and beginning of an array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - 🐛 Fixing bugs
 - ♻️ Refactoring code
 
-## v2.4.0 (2025-01-08)
+## v2.4.0 (2025-01-10)
 
 ## v2.3.0 (2024-12-29)
 - 🐛 Fixed bugs with function `len` for `STRING` type that was not handling Unicode correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## v2.4.0 (2025-01-11)
 - ✨ Added new functions for strings: `trimRight`, `trimLeft`
+- ✨ Added shortcut for using components, instead of writing `@component("components/post-card", { post })` you can now write `@component("~post-card", { post })`. `~` is an alias for the `components/` directory
 
 ## v2.3.0 (2024-12-29)
 - 🐛 Fixed bugs with function `len` for `STRING` type that was not handling Unicode correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## v2.4.0 (2025-01-11)
 - ✨ Added new functions for strings: `trimRight`, `trimLeft`, `repeat`
 - ✨ Added shortcut for using components, instead of writing `@component("components/post-card", { post })` you can now write `@component("~post-card", { post })`. `~` is an alias for the `components/` directory
+- ✨ Added `@dump` directive to dump the value of a variable to the output. This is useful for debugging purposes
+- ✨ Added `2` new functions for arrays: `append` and `prepend` to add elements to the end and beginning of an array
 
 ## v2.3.0 (2024-12-29)
 - 🐛 Fixed bugs with function `len` for `STRING` type that was not handling Unicode correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - ✨ Added shortcut for using components, instead of writing `@component("components/post-card", { post })` you can now write `@component("~post-card", { post })`. `~` is an alias for the `components/` directory
 - ✨ Added `@dump` directive to dump the value of a variable to the output. This is useful for debugging purposes
 - ✨ Added `2` new functions for arrays: `append` and `prepend` to add elements to the end and beginning of an array
+Read more in the [blogpost](https://textwire.github.io/blog/2025/01/10/textwire-v2.4.0)
 
 ## v2.3.0 (2024-12-29)
 - 🐛 Fixed bugs with function `len` for `STRING` type that was not handling Unicode correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - ♻️ Refactoring code
 
 ## v2.4.0 (2025-01-11)
-- ✨ Added new functions for strings: `trimRight`, `trimLeft`
+- ✨ Added new functions for strings: `trimRight`, `trimLeft`, `repeat`
 - ✨ Added shortcut for using components, instead of writing `@component("components/post-card", { post })` you can now write `@component("~post-card", { post })`. `~` is an alias for the `components/` directory
 
 ## v2.3.0 (2024-12-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - 🐛 Fixing bugs
 - ♻️ Refactoring code
 
-## v2.4.0 (2025-01-10)
+## v2.4.0 (2025-01-11)
+- ✨ Added new functions for strings: `trimRight`, `trimLeft`
 
 ## v2.3.0 (2024-12-29)
 - 🐛 Fixed bugs with function `len` for `STRING` type that was not handling Unicode correctly

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ go get github.com/textwire/textwire/v2
 ```
 
 ## VSCode Extension
-
 If you use [VSCode](https://code.visualstudio.com/) as your primary editor, you can install the [Textwire extension](https://marketplace.visualstudio.com/items?itemName=SerhiiCho.textwire) to get syntax highlighting and other features for Textwire.
 
 ## License
-
 The Textwire project is licensed under the [MIT License](https://github.com/textwire/textwire/blob/main/LICENSE)

--- a/ast/dump_stmt.go
+++ b/ast/dump_stmt.go
@@ -1,0 +1,41 @@
+package ast
+
+import (
+	"bytes"
+
+	"github.com/textwire/textwire/v2/token"
+)
+
+type DumpStmt struct {
+	Token     token.Token // The '@dump' token
+	Arguments []Expression
+}
+
+func (ds *DumpStmt) statementNode() {
+}
+
+func (ds *DumpStmt) TokenLiteral() string {
+	return ds.Token.Literal
+}
+
+func (ds *DumpStmt) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("@dump(")
+
+	for i, arg := range ds.Arguments {
+		out.WriteString(arg.String())
+
+		if i < len(ds.Arguments)-1 {
+			out.WriteString(",")
+		}
+	}
+
+	out.WriteString(")")
+
+	return out.String()
+}
+
+func (ss *DumpStmt) Line() uint {
+	return ss.Token.Line
+}

--- a/evaluator/array_func.go
+++ b/evaluator/array_func.go
@@ -188,3 +188,43 @@ func arrayContainsFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Ob
 
 	return &object.Bool{Value: false}, nil
 }
+
+// arrayAppendFunc appends the given elements to the given array
+func arrayAppendFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Object) (object.Object, error) {
+	if len(args) == 0 {
+		msg := fmt.Sprintf(fail.ErrFuncRequiresOneArg, "append", object.ARR_OBJ)
+		return nil, errors.New(msg)
+	}
+
+	elems := receiver.(*object.Array).Elements
+	newElems := make([]object.Object, len(elems)+len(args))
+
+	copy(newElems, elems)
+
+	for i, arg := range args {
+		newElems[len(elems)+i] = arg
+	}
+
+	return &object.Array{Elements: newElems}, nil
+}
+
+// arrayPrependFunc prepends the given elements to the given array
+func arrayPrependFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Object) (object.Object, error) {
+	argsLen := len(args)
+
+	if argsLen == 0 {
+		msg := fmt.Sprintf(fail.ErrFuncRequiresOneArg, "prepend", object.ARR_OBJ)
+		return nil, errors.New(msg)
+	}
+
+	elems := receiver.(*object.Array).Elements
+	newElems := make([]object.Object, len(elems)+argsLen)
+
+	copy(newElems, args)
+
+	for i, el := range elems {
+		newElems[argsLen+i] = el
+	}
+
+	return &object.Array{Elements: newElems}, nil
+}

--- a/evaluator/array_func_test.go
+++ b/evaluator/array_func_test.go
@@ -59,6 +59,20 @@ func TestEvalArrayFunctions(t *testing.T) {
 		{`{{ [1, 2].contains({}) }}`, "0"},
 		{`{{ [{}, 21].contains({age: 21}) }}`, "0"},
 		{`{{ [[], [1], [2]].contains([2]) }}`, "1"},
+		// append
+		{`{{ [].append(1) }}`, "1"},
+		{`{{ [1, 2, 3].append(4) }}`, "1, 2, 3, 4"},
+		{`{{ ["one", "two"].append("three") }}`, "one, two, three"},
+		{`{{ [1, 2].append(3, 4) }}`, "1, 2, 3, 4"},
+		{`{{ [1, 2].append([3, 4]) }}`, "1, 2, 3, 4"},
+		{`{{ [1, 2].append([3, 4]).len() }}`, "3"},
+		// prepend
+		{`{{ [].prepend(1) }}`, "1"},
+		{`{{ [1, 2, 3].prepend(4) }}`, "4, 1, 2, 3"},
+		{`{{ ["one", "two"].prepend("three") }}`, "three, one, two"},
+		{`{{ [1, 2].prepend(3, 4) }}`, "3, 4, 1, 2"},
+		{`{{ [1, 2].prepend([3, 4]) }}`, "3, 4, 1, 2"},
+		{`{{ [1, 2].prepend([3, 4]).len() }}`, "3"},
 	}
 
 	for _, tc := range tests {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"bytes"
+	"fmt"
 	"html"
 	"strings"
 
@@ -58,6 +59,8 @@ func (e *Evaluator) Eval(node ast.Node, env *object.Env) object.Object {
 		return e.evalContinueIfStmt(node, env)
 	case *ast.SlotStmt:
 		return e.evalSlotStmt(node, env)
+	case *ast.DumpStmt:
+		return e.evalDumpStmt(node, env)
 	case *ast.BreakStmt:
 		return BREAK
 	case *ast.ContinueStmt:
@@ -453,6 +456,17 @@ func (e *Evaluator) evalSlotStmt(
 	}
 
 	return &object.Slot{Name: node.Name.Value, Content: body}
+}
+
+func (e *Evaluator) evalDumpStmt(node *ast.DumpStmt, env *object.Env) object.Object {
+	var values []string
+
+	for _, arg := range node.Arguments {
+		val := e.Eval(arg, env)
+		values = append(values, fmt.Sprintf(object.DumpHTML, val.String()))
+	}
+
+	return &object.Dump{Values: values}
 }
 
 func (e *Evaluator) evalIdentifier(

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -463,7 +463,7 @@ func (e *Evaluator) evalDumpStmt(node *ast.DumpStmt, env *object.Env) object.Obj
 
 	for _, arg := range node.Arguments {
 		val := e.Eval(arg, env)
-		values = append(values, fmt.Sprintf(object.DumpHTML, val.String()))
+		values = append(values, fmt.Sprintf(object.DumpHTML, val.Dump(0)))
 	}
 
 	return &object.Dump{Values: values}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -179,7 +179,7 @@ func (e *Evaluator) evalAssignStmt(node *ast.AssignStmt, env *object.Env) object
 	err := env.Set(node.Name.Value, val)
 
 	if err != nil {
-		return e.newError(node, err.Error())
+		return e.newError(node, "%s", err.Error())
 	}
 
 	return NIL
@@ -333,7 +333,7 @@ func (e *Evaluator) evalForStmt(node *ast.ForStmt, env *object.Env) object.Objec
 		err := newEnv.Set(varName, post)
 
 		if err != nil {
-			return e.newError(node, err.Error())
+			return e.newError(node, "%s", err.Error())
 		}
 
 		if hasBreakStmt(block) {
@@ -372,7 +372,7 @@ func (e *Evaluator) evalEachStmt(node *ast.EachStmt, env *object.Env) object.Obj
 		err := newEnv.Set(varName, elem)
 
 		if err != nil {
-			return e.newError(node, err.Error())
+			return e.newError(node, "%s", err.Error())
 		}
 
 		newEnv.SetLoopVar(map[string]object.Object{
@@ -699,7 +699,7 @@ func (e *Evaluator) evalCallExp(
 		res, err := buitin.Fn(e.ctx, receiverObj, args...)
 
 		if err != nil {
-			return e.newError(node, err.Error())
+			return e.newError(node, "%s", err.Error())
 		}
 
 		return res

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -2,7 +2,6 @@ package evaluator
 
 import (
 	"bytes"
-	"fmt"
 	"html"
 	"strings"
 
@@ -463,7 +462,7 @@ func (e *Evaluator) evalDumpStmt(node *ast.DumpStmt, env *object.Env) object.Obj
 
 	for _, arg := range node.Arguments {
 		val := e.Eval(arg, env)
-		values = append(values, fmt.Sprintf(object.DumpHTML, val.Dump(0)))
+		values = append(values, val.Dump(0))
 	}
 
 	return &object.Dump{Values: values}

--- a/evaluator/func.go
+++ b/evaluator/func.go
@@ -10,6 +10,8 @@ var functions = map[object.ObjectType]map[string]*object.Builtin{
 		"split":      {Fn: strSplitFunc},
 		"raw":        {Fn: strRawFunc},
 		"trim":       {Fn: strTrimFunc},
+		"trimRight":  {Fn: strTrimRightFunc},
+		"trimLeft":   {Fn: strTrimLeftFunc},
 		"upper":      {Fn: strUpperFunc},
 		"lower":      {Fn: strLowerFunc},
 		"capitalize": {Fn: strCapitalizeFunc},

--- a/evaluator/func.go
+++ b/evaluator/func.go
@@ -22,6 +22,7 @@ var functions = map[object.ObjectType]map[string]*object.Builtin{
 		"at":         {Fn: strAtFunc},
 		"first":      {Fn: strFirstFunc},
 		"last":       {Fn: strLastFunc},
+		"repeat":     {Fn: strRepeatFunc},
 	},
 	object.ARR_OBJ: {
 		"len":      {Fn: arrayLenFunc},

--- a/evaluator/func.go
+++ b/evaluator/func.go
@@ -32,6 +32,8 @@ var functions = map[object.ObjectType]map[string]*object.Builtin{
 		"slice":    {Fn: arraySliceFunc},
 		"shuffle":  {Fn: arrayShuffleFunc},
 		"contains": {Fn: arrayContainsFunc},
+		"append":   {Fn: arrayAppendFunc},
+		"prepend":  {Fn: arrayPrependFunc},
 	},
 	object.FLOAT_OBJ: {
 		"int":   {Fn: floatIntFunc},

--- a/evaluator/func_test.go
+++ b/evaluator/func_test.go
@@ -38,11 +38,29 @@ func TestFunctionGivesError(t *testing.T) {
 		{`{{ "nice".split(3.0) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "split", object.STR_OBJ)},
 		{`{{ "nice".split(nil) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "split", object.STR_OBJ)},
 		// trim
-		{`{{ " nice".trim(1) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
-		{`{{ " nice".trim({}) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
-		{`{{ " nice".trim([]) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
-		{`{{ " nice".trim(3.0) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
-		{`{{ " nice".trim(nil) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
+		{`{{ "n".trim(1) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
+		{`{{ "n".trim({}) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
+		{`{{ "n".trim([]) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
+		{`{{ "n".trim(3.0) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
+		{`{{ "n".trim(nil) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trim", object.STR_OBJ)},
+		// trimRight
+		{`{{ "n".trimRight(1) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimRight", object.STR_OBJ)},
+		{`{{ "n".trimRight({}) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimRight", object.STR_OBJ)},
+		{`{{ "n".trimRight([]) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimRight", object.STR_OBJ)},
+		{`{{ "n".trimRight(3.0) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimRight", object.STR_OBJ)},
+		{`{{ "n".trimRight(nil) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimRight", object.STR_OBJ)},
+		// trimLeft
+		{`{{ "n".trimLeft(1) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimLeft", object.STR_OBJ)},
+		{`{{ "n".trimLeft({}) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimLeft", object.STR_OBJ)},
+		{`{{ "n".trimLeft([]) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimLeft", object.STR_OBJ)},
+		{`{{ "n".trimLeft(3.0) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimLeft", object.STR_OBJ)},
+		{`{{ "n".trimLeft(nil) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgStr, "trimLeft", object.STR_OBJ)},
+		// repeat
+		{`{{ "n".repeat(true) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgInt, "repeat", object.STR_OBJ)},
+		{`{{ "n".repeat(false) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgInt, "repeat", object.STR_OBJ)},
+		{`{{ "n".repeat(nil) }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgInt, "repeat", object.STR_OBJ)},
+		{`{{ "n".repeat("3") }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncFirstArgInt, "repeat", object.STR_OBJ)},
+		{`{{ "n".repeat() }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncRequiresOneArg, "repeat", object.STR_OBJ)},
 		// contains
 		{`{{ "anna".contains() }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncRequiresOneArg, "contains", object.STR_OBJ)},
 		// truncate

--- a/evaluator/func_test.go
+++ b/evaluator/func_test.go
@@ -101,6 +101,10 @@ func TestFunctionGivesError(t *testing.T) {
 		{`{{ false.then() }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncRequiresOneArg, "then", object.BOOL_OBJ)},
 		// contains
 		{`{{ [1, 2].contains() }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncRequiresOneArg, "contains", object.ARR_OBJ)},
+		// append
+		{`{{ [1, 2].append() }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncRequiresOneArg, "append", object.ARR_OBJ)},
+		// prepend
+		{`{{ [1, 2].prepend() }}`, fail.New(1, "/path/to/file", "evaluator", fail.ErrFuncRequiresOneArg, "prepend", object.ARR_OBJ)},
 	}
 
 	for _, tc := range tests {

--- a/evaluator/str_func.go
+++ b/evaluator/str_func.go
@@ -12,6 +12,8 @@ import (
 	"github.com/textwire/textwire/v2/object"
 )
 
+const defaultCharTrim = "\t \n\r"
+
 // strLenFunc returns the length of the given string
 func strLenFunc(_ *ctx.EvalCtx, receiver object.Object, _ ...object.Object) (object.Object, error) {
 	val := receiver.(*object.Str).Value
@@ -54,7 +56,7 @@ func strRawFunc(_ *ctx.EvalCtx, receiver object.Object, _ ...object.Object) (obj
 
 // strTrimFunc returns a string with leading and trailing whitespace removed
 func strTrimFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Object) (object.Object, error) {
-	chars := "\t \n\r"
+	chars := defaultCharTrim
 
 	if len(args) > 0 {
 		str, ok := args[0].(*object.Str)
@@ -217,4 +219,44 @@ func strFirstFunc(c *ctx.EvalCtx, receiver object.Object, _ ...object.Object) (o
 // strLastFunc returns the last character in the string
 func strLastFunc(c *ctx.EvalCtx, receiver object.Object, _ ...object.Object) (object.Object, error) {
 	return strAtFunc(c, receiver, &object.Int{Value: -1})
+}
+
+// strTrimRightFunc returns a string with trailing whitespace removed from the right
+func strTrimRightFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Object) (object.Object, error) {
+	chars := defaultCharTrim
+
+	if len(args) > 0 {
+		str, ok := args[0].(*object.Str)
+
+		if !ok {
+			msg := fmt.Sprintf(fail.ErrFuncFirstArgStr, "trimRight", object.STR_OBJ)
+			return nil, errors.New(msg)
+		}
+
+		chars = str.Value
+	}
+
+	val := receiver.(*object.Str).Value
+
+	return &object.Str{Value: strings.TrimRight(val, chars)}, nil
+}
+
+// strTrimLeftFunc returns a string with trailing whitespace removed from the left
+func strTrimLeftFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Object) (object.Object, error) {
+	chars := defaultCharTrim
+
+	if len(args) > 0 {
+		str, ok := args[0].(*object.Str)
+
+		if !ok {
+			msg := fmt.Sprintf(fail.ErrFuncFirstArgStr, "trimLeft", object.STR_OBJ)
+			return nil, errors.New(msg)
+		}
+
+		chars = str.Value
+	}
+
+	val := receiver.(*object.Str).Value
+
+	return &object.Str{Value: strings.TrimLeft(val, chars)}, nil
 }

--- a/evaluator/str_func.go
+++ b/evaluator/str_func.go
@@ -260,3 +260,23 @@ func strTrimLeftFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Obje
 
 	return &object.Str{Value: strings.TrimLeft(val, chars)}, nil
 }
+
+// strRepeatFunc returns a string repeated n times
+func strRepeatFunc(_ *ctx.EvalCtx, receiver object.Object, args ...object.Object) (object.Object, error) {
+	if len(args) == 0 {
+		msg := fmt.Sprintf(fail.ErrFuncRequiresOneArg, "repeat", object.STR_OBJ)
+		return nil, errors.New(msg)
+	}
+
+	firstArg, ok := args[0].(*object.Int)
+
+	if !ok {
+		msg := fmt.Sprintf(fail.ErrFuncFirstArgInt, "repeat", object.STR_OBJ)
+		return nil, errors.New(msg)
+	}
+
+	val := receiver.(*object.Str).Value
+	repeated := strings.Repeat(val, int(firstArg.Value))
+
+	return &object.Str{Value: repeated}, nil
+}

--- a/evaluator/str_func_test.go
+++ b/evaluator/str_func_test.go
@@ -37,6 +37,16 @@ func TestEvalStringFunctions(t *testing.T) {
 		{`{{ "ease".trimLeft("e") }}`, "ase"},
 		{`{{ "(no war!)".trimLeft("()") }}`, "no war!)"},
 		{`{{ " 中国很大   ".trimLeft("中 大") }}`, "国很大   "},
+		// repeat
+		{`{{ "a".repeat(3) }}`, "aaa"},
+		{`{{ "a".repeat(0) }}`, ""},
+		{`{{ "a".repeat(1) }}`, "a"},
+		{`{{ "b".repeat(10) }}`, "bbbbbbbbbb"},
+		{`{{ "".repeat(10) }}`, ""},
+		{`{{ " ".repeat(4) }}`, "    "},
+		{`{{ "nice ".repeat(4) }}`, "nice nice nice nice "},
+		{`{{ "中国 ".repeat(4) }}`, "中国 中国 中国 中国 "},
+		{`{{ "просто ".repeat(2) }}`, "просто просто "},
 		// upper
 		{`{{ "Hello World".upper() }}`, "HELLO WORLD"},
 		{`{{ "upper_-1234567890!@#$%^*()=+".upper() }}`, "UPPER_-1234567890!@#$%^*()=+"},

--- a/evaluator/str_func_test.go
+++ b/evaluator/str_func_test.go
@@ -25,6 +25,7 @@ func TestEvalStringFunctions(t *testing.T) {
 		{`{{ "ease".trim("e") }}`, "as"},
 		{`{{ "(no war!)".trim("()") }}`, "no war!"},
 		{`{{ " 中国很大   ".trim("中 大") }}`, "国很"},
+		{`{{ "😡🤣🤣🤣😤".trim("😡😤") }}`, "🤣🤣🤣"},
 		// trimRight
 		{`{{ " 	test		".trimRight() }}`, " 	test"},
 		{`{{ "ease".trimRight("e") }}`, "eas"},
@@ -47,22 +48,26 @@ func TestEvalStringFunctions(t *testing.T) {
 		{`{{ "nice ".repeat(4) }}`, "nice nice nice nice "},
 		{`{{ "中国 ".repeat(4) }}`, "中国 中国 中国 中国 "},
 		{`{{ "просто ".repeat(2) }}`, "просто просто "},
+		{`{{ '🤣'.repeat(5) }}`, "🤣🤣🤣🤣🤣"},
 		// upper
 		{`{{ "Hello World".upper() }}`, "HELLO WORLD"},
 		{`{{ "upper_-1234567890!@#$%^*()=+".upper() }}`, "UPPER_-1234567890!@#$%^*()=+"},
 		{`{{ "".upper() }}`, ""},
 		{`{{ "中国很大".upper() }}`, "中国很大"},
+		{`{{ "😡🤣😤".upper() }}`, "😡🤣😤"},
 		// lower
 		{`{{ "Hello World".lower() }}`, "hello world"},
 		{`{{ "LOWER_-1234567890!@#$%^*()=+".lower() }}`, "lower_-1234567890!@#$%^*()=+"},
 		{`{{ "".lower() }}`, ""},
 		{`{{ "中国很大".lower() }}`, "中国很大"},
+		{`{{ "😡🤣😤".lower() }}`, "😡🤣😤"},
 		// reverse
 		{`{{ "Hello World".reverse() }}`, "dlroW olleH"},
 		{`{{ "reverse_-1234567890!@#$%^*()=+".reverse() }}`, "+=)(*^%$#@!0987654321-_esrever"},
 		{`{{ "".reverse() }}`, ""},
 		{`{{ "T".reverse() }}`, "T"},
 		{`{{ "我爱中文".reverse() }}`, "文中爱我"},
+		{`{{ "😡🤣😤".reverse() }}`, "😤🤣😡"},
 		// contains
 		{`{{ "Hello World".contains("World") }}`, "1"},
 		{`{{ "Hello World".contains("world") }}`, "0"},

--- a/evaluator/str_func_test.go
+++ b/evaluator/str_func_test.go
@@ -32,6 +32,8 @@ func TestEvalStringFunctions(t *testing.T) {
 		{`{{ " 中国很大   ".trimRight("中 大") }}`, " 中国很"},
 		// trimLeft
 		{`{{ " 	test		".trimLeft() }}`, "test		"},
+		{`{{ "Textwire".trimLeft('t') }}`, "Textwire"},
+		{`{{ "Textwire".trimLeft('T') }}`, "extwire"},
 		{`{{ "ease".trimLeft("e") }}`, "ase"},
 		{`{{ "(no war!)".trimLeft("()") }}`, "no war!)"},
 		{`{{ " 中国很大   ".trimLeft("中 大") }}`, "国很大   "},

--- a/evaluator/str_func_test.go
+++ b/evaluator/str_func_test.go
@@ -25,6 +25,16 @@ func TestEvalStringFunctions(t *testing.T) {
 		{`{{ "ease".trim("e") }}`, "as"},
 		{`{{ "(no war!)".trim("()") }}`, "no war!"},
 		{`{{ " 中国很大   ".trim("中 大") }}`, "国很"},
+		// trimRight
+		{`{{ " 	test		".trimRight() }}`, " 	test"},
+		{`{{ "ease".trimRight("e") }}`, "eas"},
+		{`{{ "(no war!)".trimRight("()") }}`, "(no war!"},
+		{`{{ " 中国很大   ".trimRight("中 大") }}`, " 中国很"},
+		// trimLeft
+		{`{{ " 	test		".trimLeft() }}`, "test		"},
+		{`{{ "ease".trimLeft("e") }}`, "ase"},
+		{`{{ "(no war!)".trimLeft("()") }}`, "no war!)"},
+		{`{{ " 中国很大   ".trimLeft("中 大") }}`, "国很大   "},
 		// upper
 		{`{{ "Hello World".upper() }}`, "HELLO WORLD"},
 		{`{{ "upper_-1234567890!@#$%^*()=+".upper() }}`, "UPPER_-1234567890!@#$%^*()=+"},

--- a/example/templates/home.tw.html
+++ b/example/templates/home.tw.html
@@ -6,6 +6,8 @@
     <h2>{{ title }}</h2>
     <h3>Email is serhii@mail.com</h3>
 
+    @dump(names, showNames, title, books)
+
     <h3>Names:</h3>
 
     @if(showNames)

--- a/example/templates/home.tw.html
+++ b/example/templates/home.tw.html
@@ -6,8 +6,6 @@
     <h2>{{ title }}</h2>
     <h3>Email is serhii@mail.com</h3>
 
-    @dump(names, showNames, title, books)
-
     <h3>Names:</h3>
 
     @if(showNames)

--- a/fail/fail.go
+++ b/fail/fail.go
@@ -24,6 +24,7 @@ const (
 	ErrDefaultSlotNotDefined     = "default slot is not defined in the component '%s'"
 	ErrDuplicateSlotUsage        = "duplicate slot usage '%s' found %d times in the component '%s'"
 	ErrDuplicateDefaultSlotUsage = "duplicate default slot usage found %d times in the component '%s'"
+	ErrExpectedComponentName     = "expected component name, got empty string instead"
 
 	// Evaluator (interpreter) errors
 	ErrUnknownNodeType         = "unknown node type '%T'"

--- a/fail/fail.go
+++ b/fail/fail.go
@@ -82,15 +82,25 @@ func New(line uint, filepath, origin, msg string, args ...interface{}) *Error {
 	}
 }
 
-// String returns the full error message with all the details
-func (e *Error) String() string {
+// Meta returns the error meta information like the file path and line number
+func (e *Error) Meta() string {
 	var path string
 
 	if e.filepath != "" {
 		path = fmt.Sprintf(" in %s", e.filepath)
 	}
 
-	return fmt.Sprintf("[Textwire ERROR%s:%d]: %s", path, e.line, e.message)
+	return fmt.Sprintf("Textwire ERROR%s:%d", path, e.line)
+}
+
+// Message returns the error message
+func (e *Error) Message() string {
+	return e.message
+}
+
+// String returns the full error message with all the details
+func (e *Error) String() string {
+	return fmt.Sprintf("[%s]: %s", e.Meta(), e.Message())
 }
 
 // FatalOnError calls log.Fatal if the error message is not empty

--- a/object/array.go
+++ b/object/array.go
@@ -2,7 +2,6 @@ package object
 
 import (
 	"bytes"
-	"strings"
 )
 
 type Array struct {
@@ -28,7 +27,6 @@ func (a *Array) String() string {
 }
 
 func (a *Array) Dump(ident int) string {
-	spaces := strings.Repeat("  ", ident)
 	ident += 1
 
 	var out bytes.Buffer
@@ -36,7 +34,6 @@ func (a *Array) Dump(ident int) string {
 	out.WriteString("<span class='textwire-brace'>[</span>")
 
 	for i, elem := range a.Elements {
-		out.WriteString(spaces)
 		out.WriteString(elem.Dump(ident))
 
 		if i < len(a.Elements)-1 {
@@ -53,7 +50,7 @@ func (a *Array) Dump(ident int) string {
 		res += "\n"
 	}
 
-	return res + "<span class='textwire-brace'>]</span>\n"
+	return res + "<span class='textwire-brace'>]</span>"
 }
 
 func (a *Array) Val() interface{} {

--- a/object/array.go
+++ b/object/array.go
@@ -28,29 +28,32 @@ func (a *Array) String() string {
 }
 
 func (a *Array) Dump(ident int) string {
-	spaces := strings.Repeat(" ", ident)
+	spaces := strings.Repeat("  ", ident)
 	ident += 1
 
 	var out bytes.Buffer
 
-	out.WriteString("<span class='textwire-brace'>[</span>\n")
+	out.WriteString("<span class='textwire-brace'>[</span>")
 
-	idx := 0
-	last := len(a.Elements) - 1
+	for i, elem := range a.Elements {
+		out.WriteString(spaces)
+		out.WriteString(elem.Dump(ident))
 
-	for _, elem := range a.Elements {
-		out.WriteString(spaces + elem.Dump(ident))
-
-		if idx != last {
-			out.WriteString(",\n")
+		if i < len(a.Elements)-1 {
+			out.WriteString(", ")
 		}
-
-		idx++
 	}
 
-	out.WriteString("<span class='textwire-brace'>]</span>\n")
+	res := out.String()
 
-	return out.String()
+	// take last 8 characters of the string
+	lastChar := res[len(res)-8:]
+
+	if lastChar == "}</span>" {
+		res += "\n"
+	}
+
+	return res + "<span class='textwire-brace'>]</span>\n"
 }
 
 func (a *Array) Val() interface{} {

--- a/object/array.go
+++ b/object/array.go
@@ -2,6 +2,8 @@ package object
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 )
 
 type Array struct {
@@ -27,18 +29,20 @@ func (a *Array) String() string {
 }
 
 func (a *Array) Dump(ident int) string {
+	spaces := strings.Repeat("  ", ident)
 	ident += 1
 
 	var out bytes.Buffer
 
-	out.WriteString("<span class='textwire-brace'>[</span>")
+	out.WriteString(fmt.Sprintf("<span class='textwire-meta'>array:%d </span>", len(a.Elements)))
+	out.WriteString("<span class='textwire-brace'>[</span>\n")
 
-	for i, elem := range a.Elements {
+	insideSpaces := strings.Repeat("  ", ident)
+
+	for _, elem := range a.Elements {
+		out.WriteString(insideSpaces)
 		out.WriteString(elem.Dump(ident))
-
-		if i < len(a.Elements)-1 {
-			out.WriteString(", ")
-		}
+		out.WriteString(",\n")
 	}
 
 	res := out.String()
@@ -50,7 +54,7 @@ func (a *Array) Dump(ident int) string {
 		res += "\n"
 	}
 
-	return res + "<span class='textwire-brace'>]</span>"
+	return res + spaces + "<span class='textwire-brace'>]</span>"
 }
 
 func (a *Array) Val() interface{} {

--- a/object/array.go
+++ b/object/array.go
@@ -1,6 +1,9 @@
 package object
 
-import "bytes"
+import (
+	"bytes"
+	"strings"
+)
 
 type Array struct {
 	Elements []Object
@@ -20,6 +23,32 @@ func (a *Array) String() string {
 	if out.Len() > 1 {
 		out.Truncate(out.Len() - 2)
 	}
+
+	return out.String()
+}
+
+func (a *Array) Dump(ident int) string {
+	spaces := strings.Repeat(" ", ident)
+	ident += 1
+
+	var out bytes.Buffer
+
+	out.WriteString("<span class='textwire-brace'>[</span>\n")
+
+	idx := 0
+	last := len(a.Elements) - 1
+
+	for _, elem := range a.Elements {
+		out.WriteString(spaces + elem.Dump(ident))
+
+		if idx != last {
+			out.WriteString(",\n")
+		}
+
+		idx++
+	}
+
+	out.WriteString("<span class='textwire-brace'>]</span>\n")
 
 	return out.String()
 }

--- a/object/block.go
+++ b/object/block.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"strings"
 )
 
 type Block struct {
@@ -17,6 +18,19 @@ func (b *Block) String() string {
 
 	for _, e := range b.Elements {
 		out.WriteString(e.String())
+	}
+
+	return out.String()
+}
+
+func (b *Block) Dump(ident int) string {
+	spaces := strings.Repeat(" ", ident)
+	ident += 1
+
+	var out bytes.Buffer
+
+	for _, e := range b.Elements {
+		out.WriteString(spaces + e.Dump(ident))
 	}
 
 	return out.String()

--- a/object/block.go
+++ b/object/block.go
@@ -24,7 +24,7 @@ func (b *Block) String() string {
 }
 
 func (b *Block) Dump(ident int) string {
-	spaces := strings.Repeat(" ", ident)
+	spaces := strings.Repeat("  ", ident)
 	ident += 1
 
 	var out bytes.Buffer

--- a/object/boolean.go
+++ b/object/boolean.go
@@ -16,6 +16,14 @@ func (b *Bool) String() string {
 	return "0"
 }
 
+func (b *Bool) Dump(ident int) string {
+	if b.Value {
+		return "<span class='textwire-key'>true</span>"
+	}
+
+	return "<span class='textwire-key'>false</span>"
+}
+
 func (b *Bool) Val() interface{} {
 	return b.Value
 }

--- a/object/boolean.go
+++ b/object/boolean.go
@@ -18,10 +18,10 @@ func (b *Bool) String() string {
 
 func (b *Bool) Dump(ident int) string {
 	if b.Value {
-		return "<span class='textwire-key'>true</span>"
+		return "<span class='textwire-keyword'>true</span>"
 	}
 
-	return "<span class='textwire-key'>false</span>"
+	return "<span class='textwire-keyword'>false</span>"
 }
 
 func (b *Bool) Val() interface{} {

--- a/object/break.go
+++ b/object/break.go
@@ -11,7 +11,7 @@ func (b *Break) String() string {
 }
 
 func (b *Break) Dump(ident int) string {
-	return ""
+	return "break stmt"
 }
 
 func (b *Break) Val() interface{} {

--- a/object/break.go
+++ b/object/break.go
@@ -10,6 +10,10 @@ func (b *Break) String() string {
 	return ""
 }
 
+func (b *Break) Dump(ident int) string {
+	return ""
+}
+
 func (b *Break) Val() interface{} {
 	return nil
 }

--- a/object/builtin.go
+++ b/object/builtin.go
@@ -12,10 +12,14 @@ func (b *Builtin) Type() ObjectType {
 	return BUILTIN_OBJ
 }
 
-func (b *Builtin) Val() interface{} {
-	return b.Fn
-}
-
 func (b *Builtin) String() string {
 	return "builtin function"
+}
+
+func (b *Builtin) Dump(ident int) string {
+	return "builtin"
+}
+
+func (b *Builtin) Val() interface{} {
+	return b.Fn
 }

--- a/object/component.go
+++ b/object/component.go
@@ -13,6 +13,10 @@ func (c *Component) String() string {
 	return c.Content.String()
 }
 
+func (c *Component) Dump(ident int) string {
+	return c.Content.Dump(ident)
+}
+
 func (c *Component) Val() interface{} {
 	return c.Content.Val()
 }

--- a/object/continue.go
+++ b/object/continue.go
@@ -10,6 +10,10 @@ func (c *Continue) String() string {
 	return ""
 }
 
+func (c *Continue) Dump(ident int) string {
+	return "continue"
+}
+
 func (c *Continue) Val() interface{} {
 	return nil
 }

--- a/object/continue.go
+++ b/object/continue.go
@@ -11,7 +11,7 @@ func (c *Continue) String() string {
 }
 
 func (c *Continue) Dump(ident int) string {
-	return "continue"
+	return "continue stmt"
 }
 
 func (c *Continue) Val() interface{} {

--- a/object/dump.go
+++ b/object/dump.go
@@ -15,15 +15,15 @@ var DumpHTML = `<style>
 }
 
 .textwire-str {
-	color: #75cf62;
+	color: #c3e88d;
 }
 
 .textwire-num {
-	color: #5090ff;
+	color: #76a8ff;
 }
 
 .textwire-key {
-	color: #f8f8f2;
+	color: #c792ea;
 }
 
 .textwire-brace {
@@ -31,7 +31,7 @@ var DumpHTML = `<style>
 }
 
 .textwire-dump pre {
-	background-color: #0b0019;
+	background-color: #212121;
 	color: white;
 	padding: 13px;
 	border-radius: 5px;

--- a/object/dump.go
+++ b/object/dump.go
@@ -1,8 +1,11 @@
 package object
 
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+)
 
-var DumpHTML = `<style>
+var outputHTML = `<style>
 .textwire-dump {
 	overflow-x: auto;
 	overflow-y: hidden;
@@ -38,9 +41,8 @@ func (d *Dump) Type() ObjectType {
 
 func (d *Dump) String() string {
 	var out bytes.Buffer
-
 	for _, v := range d.Values {
-		out.WriteString(v)
+		out.WriteString(fmt.Sprintf(outputHTML, v))
 	}
 
 	return out.String()

--- a/object/dump.go
+++ b/object/dump.go
@@ -13,13 +13,14 @@ var DumpHTML = `<style>
 .textwire-prop { color: #f8f8f2 }
 .textwire-str { color: #c3e88d }
 .textwire-num { color: #76a8ff }
-.textwire-key { color: #c792ea }
+.textwire-keyword { color: #c792ea }
 .textwire-brace { color: #e99f33 }
+.textwire-meta { color:#2c8ed0 }
 
 .textwire-dump pre {
 	background-color: #212121;
 	color: white;
-	padding: 13px;
+	padding: 20px;
 	border-radius: 5px;
 	margin: 0 !important;
 	width: fit-content;

--- a/object/dump.go
+++ b/object/dump.go
@@ -7,6 +7,27 @@ var DumpHTML = `<style>
 	overflow-x: auto;
 	overflow-y: hidden;
     scrollbar-width: thin;
+	margin: 4px;
+}
+
+.textwire-prop {
+	color: #f8f8f2;
+}
+
+.textwire-str {
+	color: #75cf62;
+}
+
+.textwire-num {
+	color: #5090ff;
+}
+
+.textwire-key {
+	color: #f8f8f2;
+}
+
+.textwire-brace {
+	color: #e99f33;
 }
 
 .textwire-dump pre {
@@ -39,7 +60,7 @@ func (d *Dump) String() string {
 }
 
 func (d *Dump) Dump(ident int) string {
-	return "dump"
+	return "dump stmt"
 }
 
 func (d *Dump) Val() interface{} {

--- a/object/dump.go
+++ b/object/dump.go
@@ -10,25 +10,11 @@ var DumpHTML = `<style>
 	margin: 4px;
 }
 
-.textwire-prop {
-	color: #f8f8f2;
-}
-
-.textwire-str {
-	color: #c3e88d;
-}
-
-.textwire-num {
-	color: #76a8ff;
-}
-
-.textwire-key {
-	color: #c792ea;
-}
-
-.textwire-brace {
-	color: #e99f33;
-}
+.textwire-prop { color: #f8f8f2 }
+.textwire-str { color: #c3e88d }
+.textwire-num { color: #76a8ff }
+.textwire-key { color: #c792ea }
+.textwire-brace { color: #e99f33 }
 
 .textwire-dump pre {
 	background-color: #212121;

--- a/object/dump.go
+++ b/object/dump.go
@@ -1,0 +1,53 @@
+package object
+
+import "bytes"
+
+var DumpHTML = `<style>
+.textwire-dump {
+	overflow-x: auto;
+	overflow-y: hidden;
+    scrollbar-width: thin;
+}
+
+.textwire-dump pre {
+	background-color: #0b0019;
+	color: white;
+	padding: 13px;
+	border-radius: 5px;
+	margin: 0 !important;
+	width: fit-content;
+}
+</style>
+<div class="textwire-dump"><pre>%s</pre></div>`
+
+type Dump struct {
+	Values []string
+}
+
+func (d *Dump) Type() ObjectType {
+	return DUMP_OBJ
+}
+
+func (d *Dump) String() string {
+	var out bytes.Buffer
+
+	for _, v := range d.Values {
+		out.WriteString(v)
+	}
+
+	return out.String()
+}
+
+func (d *Dump) Val() interface{} {
+	var result []interface{}
+
+	for _, v := range d.Values {
+		result = append(result, v)
+	}
+
+	return result
+}
+
+func (d *Dump) Is(t ObjectType) bool {
+	return t == d.Type()
+}

--- a/object/dump.go
+++ b/object/dump.go
@@ -38,6 +38,10 @@ func (d *Dump) String() string {
 	return out.String()
 }
 
+func (d *Dump) Dump(ident int) string {
+	return "dump"
+}
+
 func (d *Dump) Val() interface{} {
 	var result []interface{}
 

--- a/object/env.go
+++ b/object/env.go
@@ -37,7 +37,7 @@ func EnvFromMap(data map[string]interface{}) (*Env, *fail.Error) {
 		err := env.Set(key, obj)
 
 		if err != nil {
-			return nil, fail.New(0, "", "template", err.Error())
+			return nil, fail.New(0, "", "template", "%s", err.Error())
 		}
 	}
 

--- a/object/error.go
+++ b/object/error.go
@@ -14,6 +14,10 @@ func (e *Error) String() string {
 	return e.Err.String()
 }
 
+func (e *Error) Dump(ident int) string {
+	return "error object"
+}
+
 func (e *Error) Val() interface{} {
 	return e.Err.String()
 }

--- a/object/error.go
+++ b/object/error.go
@@ -22,10 +22,10 @@ func (e *Error) String() string {
 func (e *Error) Dump(ident int) string {
 	var out bytes.Buffer
 
-	out.WriteString("<span class='textwire-meta'>error >>></span>\n")
+	out.WriteString("<span class='textwire-meta'>error\"\"\"</span>\n")
 	out.WriteString(fmt.Sprintf("<span class='textwire-key'>%s</span>\n\n", e.Err.Meta()))
 	out.WriteString(fmt.Sprintf("<span class='textwire-str'>%s</span>\n", e.Err.Message()))
-	out.WriteString("<span class='textwire-meta'><<<</span>")
+	out.WriteString("<span class='textwire-meta'>\"\"\"</span>")
 
 	return out.String()
 }

--- a/object/error.go
+++ b/object/error.go
@@ -1,6 +1,11 @@
 package object
 
-import "github.com/textwire/textwire/v2/fail"
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/textwire/textwire/v2/fail"
+)
 
 type Error struct {
 	Err *fail.Error
@@ -15,7 +20,14 @@ func (e *Error) String() string {
 }
 
 func (e *Error) Dump(ident int) string {
-	return "error object"
+	var out bytes.Buffer
+
+	out.WriteString("<span class='textwire-meta'>error >>></span>\n")
+	out.WriteString(fmt.Sprintf("<span class='textwire-key'>%s</span>\n\n", e.Err.Meta()))
+	out.WriteString(fmt.Sprintf("<span class='textwire-str'>%s</span>\n", e.Err.Message()))
+	out.WriteString("<span class='textwire-meta'><<<</span>")
+
+	return out.String()
 }
 
 func (e *Error) Val() interface{} {

--- a/object/float.go
+++ b/object/float.go
@@ -25,6 +25,10 @@ func (f *Float) String() string {
 	return utils.FloatToStr(f.Value)
 }
 
+func (f *Float) Dump(ident int) string {
+	return "<span class='textwire-key'>" + f.String() + "</span>"
+}
+
 func (f *Float) Val() interface{} {
 	return f.Value
 }

--- a/object/float.go
+++ b/object/float.go
@@ -26,7 +26,7 @@ func (f *Float) String() string {
 }
 
 func (f *Float) Dump(ident int) string {
-	return "<span class='textwire-key'>" + f.String() + "</span>"
+	return "<span class='textwire-num'>" + f.String() + "</span>"
 }
 
 func (f *Float) Val() interface{} {

--- a/object/html.go
+++ b/object/html.go
@@ -12,6 +12,10 @@ func (h *HTML) String() string {
 	return h.Value
 }
 
+func (h *HTML) Dump(ident int) string {
+	return h.Value
+}
+
 func (h *HTML) Val() interface{} {
 	return h.Value
 }

--- a/object/int.go
+++ b/object/int.go
@@ -1,6 +1,8 @@
 package object
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Int struct {
 	Value int64
@@ -12,6 +14,10 @@ func (i *Int) Type() ObjectType {
 
 func (i *Int) String() string {
 	return fmt.Sprintf("%d", i.Value)
+}
+
+func (i *Int) Dump(ident int) string {
+	return fmt.Sprintf("<span class='textwire-key'>%d</span>", i.Value)
 }
 
 func (i *Int) Val() interface{} {

--- a/object/int.go
+++ b/object/int.go
@@ -17,7 +17,7 @@ func (i *Int) String() string {
 }
 
 func (i *Int) Dump(ident int) string {
-	return fmt.Sprintf("<span class='textwire-key'>%d</span>", i.Value)
+	return fmt.Sprintf("<span class='textwire-num'>%d</span>", i.Value)
 }
 
 func (i *Int) Val() interface{} {

--- a/object/nil.go
+++ b/object/nil.go
@@ -11,7 +11,7 @@ func (n *Nil) String() string {
 }
 
 func (n *Nil) Dump(ident int) string {
-	return "<span class='textwire-key'>nil</span>"
+	return "<span class='textwire-keyword'>nil</span>"
 }
 
 func (n *Nil) Val() interface{} {

--- a/object/nil.go
+++ b/object/nil.go
@@ -10,6 +10,10 @@ func (n *Nil) String() string {
 	return ""
 }
 
+func (n *Nil) Dump(ident int) string {
+	return "<span class='textwire-key'>nil</span>"
+}
+
 func (n *Nil) Val() interface{} {
 	return nil
 }

--- a/object/obj.go
+++ b/object/obj.go
@@ -2,7 +2,6 @@ package object
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 )
 
@@ -38,28 +37,26 @@ func (o *Obj) String() string {
 }
 
 func (o *Obj) Dump(ident int) string {
-	spaces := strings.Repeat(" ", ident)
+	spaces := strings.Repeat("  ", ident)
 	ident += 1
 
 	var out bytes.Buffer
 
+	out.WriteString("\n" + spaces)
 	out.WriteString("<span class='textwire-brace'>{</span>\n")
 
-	idx := 0
-	last := len(o.Pairs) - 1
+	ident += 1
+	insideSpaces := strings.Repeat("  ", ident)
 
 	for key, pair := range o.Pairs {
-		str := fmt.Sprintf("%s<span class='textwire-str'>%s</span>: %s", spaces, key, pair.Dump(ident))
-		out.WriteString(str)
-
-		if idx != last {
-			out.WriteString(", ")
-		}
-
-		idx++
+		out.WriteString(insideSpaces)
+		out.WriteString(`<span class="textwire-prop">"` + key + `"</span>`)
+		out.WriteString(": ")
+		out.WriteString(pair.Dump(ident))
+		out.WriteString(",\n")
 	}
 
-	out.WriteString("<span class='textwire-brace'>}</span>\n")
+	out.WriteString(spaces + "<span class='textwire-brace'>}</span>")
 
 	return out.String()
 }

--- a/object/obj.go
+++ b/object/obj.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 )
 
@@ -42,10 +43,9 @@ func (o *Obj) Dump(ident int) string {
 
 	var out bytes.Buffer
 
-	out.WriteString("\n" + spaces)
+	out.WriteString(fmt.Sprintf("<span class='textwire-meta'>object:%d </span>", len(o.Pairs)))
 	out.WriteString("<span class='textwire-brace'>{</span>\n")
 
-	ident += 1
 	insideSpaces := strings.Repeat("  ", ident)
 
 	for key, pair := range o.Pairs {

--- a/object/obj.go
+++ b/object/obj.go
@@ -1,6 +1,10 @@
 package object
 
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
 
 type Obj struct {
 	Pairs map[string]Object
@@ -29,6 +33,33 @@ func (o *Obj) String() string {
 	}
 
 	out.WriteString("}")
+
+	return out.String()
+}
+
+func (o *Obj) Dump(ident int) string {
+	spaces := strings.Repeat(" ", ident)
+	ident += 1
+
+	var out bytes.Buffer
+
+	out.WriteString("<span class='textwire-brace'>{</span>\n")
+
+	idx := 0
+	last := len(o.Pairs) - 1
+
+	for key, pair := range o.Pairs {
+		str := fmt.Sprintf("%s<span class='textwire-str'>%s</span>: %s", spaces, key, pair.Dump(ident))
+		out.WriteString(str)
+
+		if idx != last {
+			out.WriteString(", ")
+		}
+
+		idx++
+	}
+
+	out.WriteString("<span class='textwire-brace'>}</span>\n")
 
 	return out.String()
 }

--- a/object/object.go
+++ b/object/object.go
@@ -20,6 +20,7 @@ const (
 	BUILTIN_OBJ   ObjectType = "FUNCTION"
 	COMPONENT_OBJ ObjectType = "COMPONENT"
 	SLOT_OBJ      ObjectType = "SLOT"
+	DUMP_OBJ      ObjectType = "DUMP"
 
 	BREAK_OBJ       ObjectType = "BREAK"
 	BREAK_IF_OBJ    ObjectType = "BREAK_IF"

--- a/object/object.go
+++ b/object/object.go
@@ -31,6 +31,7 @@ const (
 type Object interface {
 	Type() ObjectType
 	String() string
+	Dump(ident int) string
 	Is(ObjectType) bool
 	Val() interface{}
 }

--- a/object/reserve.go
+++ b/object/reserve.go
@@ -18,6 +18,10 @@ func (r *Reserve) String() string {
 	return r.Content.String()
 }
 
+func (r *Reserve) Dump(ident int) string {
+	return "reserve"
+}
+
 func (r *Reserve) Val() interface{} {
 	return r.Content.Val()
 }

--- a/object/reserve.go
+++ b/object/reserve.go
@@ -19,7 +19,7 @@ func (r *Reserve) String() string {
 }
 
 func (r *Reserve) Dump(ident int) string {
-	return "reserve"
+	return "reserve stmt"
 }
 
 func (r *Reserve) Val() interface{} {

--- a/object/slot.go
+++ b/object/slot.go
@@ -18,7 +18,7 @@ func (s *Slot) String() string {
 }
 
 func (s *Slot) Dump(ident int) string {
-	return "slot"
+	return "slot stmt"
 }
 
 func (s *Slot) Val() interface{} {

--- a/object/slot.go
+++ b/object/slot.go
@@ -17,6 +17,10 @@ func (s *Slot) String() string {
 	return s.Content.String()
 }
 
+func (s *Slot) Dump(ident int) string {
+	return "slot"
+}
+
 func (s *Slot) Val() interface{} {
 	return s.Content.Val()
 }

--- a/object/string.go
+++ b/object/string.go
@@ -1,5 +1,7 @@
 package object
 
+import "fmt"
+
 type Str struct {
 	Value string
 }
@@ -10,6 +12,10 @@ func (s *Str) Type() ObjectType {
 
 func (s *Str) String() string {
 	return s.Value
+}
+
+func (s *Str) Dump(ident int) string {
+	return fmt.Sprintf("<span class='textwire-str'>%q</span>", s.Value)
 }
 
 func (s *Str) Val() interface{} {

--- a/object/use.go
+++ b/object/use.go
@@ -13,6 +13,10 @@ func (u *Use) String() string {
 	return u.Content.String()
 }
 
+func (u *Use) Dump(ident int) string {
+	return "use"
+}
+
 func (u *Use) Val() interface{} {
 	return u.Content.Val()
 }

--- a/object/use.go
+++ b/object/use.go
@@ -14,7 +14,7 @@ func (u *Use) String() string {
 }
 
 func (u *Use) Dump(ident int) string {
-	return "use"
+	return "use stmt"
 }
 
 func (u *Use) Val() interface{} {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -181,6 +181,8 @@ func (p *Parser) parseStatement() ast.Statement {
 		return p.parseComponentStmt()
 	case token.SLOT:
 		return p.parseSlotStmt()
+	case token.DUMP:
+		return p.parseDumpStmt()
 	case token.BREAK:
 		return &ast.BreakStmt{Token: p.curToken}
 	case token.CONTINUE:
@@ -546,6 +548,23 @@ func (p *Parser) parseSlotStmt() *ast.SlotStmt {
 	return &ast.SlotStmt{
 		Token: tok, // "@slot"
 		Name:  slotName,
+	}
+}
+
+func (p *Parser) parseDumpStmt() *ast.DumpStmt {
+	tok := p.curToken // "@dump"
+
+	var args []ast.Expression
+
+	if !p.expectPeek(token.LPAREN) { // move to "("
+		return nil
+	}
+
+	args = p.parseExpressionList(token.RPAREN)
+
+	return &ast.DumpStmt{
+		Token:     tok,
+		Arguments: args,
 	}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -466,7 +466,7 @@ func (p *Parser) parseComponentStmt() ast.Statement {
 
 	stmt.Name = &ast.StringLiteral{
 		Token: p.curToken,
-		Value: p.curToken.Literal,
+		Value: p.parseComponentName(),
 	}
 
 	if p.peekTokenIs(token.COMMA) {
@@ -502,6 +502,21 @@ func (p *Parser) parseComponentStmt() ast.Statement {
 	p.components = append(p.components, stmt)
 
 	return stmt
+}
+
+func (p *Parser) parseComponentName() string {
+	name := p.curToken.Literal
+
+	if name == "" {
+		p.newError(p.curToken.Line, fail.ErrExpectedComponentName)
+		return ""
+	}
+
+	if name[0] == '~' {
+		name = "components/" + name[1:]
+	}
+
+	return name
 }
 
 // parseSlotStmt parses a slot statement inside a component file.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -612,17 +612,9 @@ func TestTernaryExp(t *testing.T) {
 		t.Fatalf("stmt is not a TernaryExp, got %T", stmt.Expression)
 	}
 
-	if !testBooleanLiteral(t, exp.Condition, true) {
-		return
-	}
-
-	if !testIntegerLiteral(t, exp.Consequence, 100) {
-		return
-	}
-
-	if !testStringLiteral(t, exp.Alternative, "Some string") {
-		return
-	}
+	testBooleanLiteral(t, exp.Condition, true)
+	testIntegerLiteral(t, exp.Consequence, 100)
+	testStringLiteral(t, exp.Alternative, "Some string")
 }
 
 func TestParseIfStmt(t *testing.T) {
@@ -1534,4 +1526,23 @@ func TestParseSlotDirective(t *testing.T) {
 			t.Fatalf("slotStmt.String() is not @slot, got `%s`", slotStmt.String())
 		}
 	})
+}
+
+func TestParseDumpStmt(t *testing.T) {
+	inp := `@dump("test", 1 + 2, false)`
+
+	stmts := parseStatements(t, inp, 1, nil)
+	stmt, ok := stmts[0].(*ast.DumpStmt)
+
+	if !ok {
+		t.Fatalf("stmts[0] is not an DumpStmt, got %T", stmts[0])
+	}
+
+	if len(stmt.Arguments) != 3 {
+		t.Fatalf("len(stmt.Arguments) is not 3, got %d", len(stmt.Arguments))
+	}
+
+	testStringLiteral(t, stmt.Arguments[0], "test")
+	testInfixExp(t, stmt.Arguments[1], 1, "+", 2)
+	testBooleanLiteral(t, stmt.Arguments[2], false)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -571,6 +571,10 @@ func TestErrorHandling(t *testing.T) {
 			fail.New(1, "", "parser", fail.ErrNoPrefixParseFunc,
 				token.String(token.RPAREN)),
 		},
+		{
+			"@component('')",
+			fail.New(1, "", "parser", fail.ErrExpectedComponentName),
+		},
 	}
 
 	for _, tc := range tests {

--- a/template.go
+++ b/template.go
@@ -25,7 +25,7 @@ func (t *Template) String(filename string, data map[string]interface{}) (string,
 	absPath, err := getFullPath(filename, true)
 
 	if err != nil {
-		return "", fail.New(0, filename, "template", err.Error())
+		return "", fail.New(0, filename, "template", "%s", err.Error())
 	}
 
 	prog, ok := t.programs[filename]

--- a/template_test.go
+++ b/template_test.go
@@ -1,7 +1,6 @@
 package textwire
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/textwire/textwire/v2/config"
@@ -33,7 +32,7 @@ func TestErrorHandlingEvaluatingTemplate(t *testing.T) {
 				2,
 				path+"unknown-slot/index.tw.html",
 				"parser",
-				fmt.Sprintf(fail.ErrSlotNotDefined, "unknown", "user"),
+				fail.ErrSlotNotDefined, "unknown", "user",
 			),
 			nil,
 		},
@@ -43,7 +42,7 @@ func TestErrorHandlingEvaluatingTemplate(t *testing.T) {
 				2,
 				path+"unknown-default-slot/index.tw.html",
 				"parser",
-				fmt.Sprintf(fail.ErrDefaultSlotNotDefined, "book"),
+				fail.ErrDefaultSlotNotDefined, "book",
 			),
 			nil,
 		},
@@ -53,7 +52,7 @@ func TestErrorHandlingEvaluatingTemplate(t *testing.T) {
 				2,
 				path+"duplicate-slot/index.tw.html",
 				"parser",
-				fmt.Sprintf(fail.ErrDuplicateSlotUsage, "content", 2, "user"),
+				fail.ErrDuplicateSlotUsage, "content", 2, "user",
 			),
 			nil,
 		},
@@ -63,7 +62,7 @@ func TestErrorHandlingEvaluatingTemplate(t *testing.T) {
 				2,
 				path+"duplicate-default-slot/index.tw.html",
 				"parser",
-				fmt.Sprintf(fail.ErrDuplicateSlotUsage, "", 2, "user"),
+				fail.ErrDuplicateSlotUsage, "", 2, "user",
 			),
 			nil,
 		},

--- a/testdata/good/before/11.with-component-no-args.tw.html
+++ b/testdata/good/before/11.with-component-no-args.tw.html
@@ -1,2 +1,2 @@
 <ul>@component('components/user2')</ul>
-<ol>@component('components/user2')</ol>
+<ol>@component('~user2')</ol>

--- a/token/token.go
+++ b/token/token.go
@@ -72,6 +72,7 @@ const (
 	CONTINUE
 	COMPONENT
 	SLOT
+	DUMP
 )
 
 var keywords = map[string]TokenType{
@@ -98,6 +99,7 @@ var directives = map[string]TokenType{
 	"@breakIf":    BREAK_IF,
 	"@component":  COMPONENT,
 	"@slot":       SLOT,
+	"@dump":       DUMP,
 }
 
 type Token struct {


### PR DESCRIPTION
- ✨ Added 3 new functions for strings: `trimRight`, `trimLeft`, `repeat`
- ✨ Added shortcut for using components, instead of writing `@component("components/post-card", { post })` you can now write `@component("~post-card", { post })`. `~` is an alias for the `components/` directory
- ✨ Added `@dump` directive to dump the value of a variable to the output. This is useful for debugging purposes
- ✨ Added `2` new functions for arrays: `append` and `prepend` to add elements to the end and beginning of an array
Read more in the [blogpost](https://textwire.github.io/blog/2025/01/10/textwire-v2.4.0)