### PR TITLE
V2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## v2.6.0 (2025-06-04)
+- Improve parser implementation by making it more resilient to syntax errors. It now produces an IllegalNode ast token
+
 ## v2.5.9 (2025-05-29)
 - Added more tests to test `IsInLoop` function
 - Fixed `IsInLoop` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release notes
 
-## v2.6.0 (2025-06-04)
-- Improve parser implementation by making it more resilient to syntax errors. It now produces an IllegalNode ast token
+## v2.6.0 (2025-06-07)
+- Improve parser implementation by making it more resilient to syntax errors. It now produces an IllegalNode ast token. I'll be able to use it to detect illegal parts in a file and show it with a red squiggly line
 - Improve testing for the parser by adding more checks
+- Added validation for `@use` statement. Now, if you pass something other than type STR, it will print an error
 
 ## v2.5.9 (2025-05-29)
 - Added more tests to test `IsInLoop` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.6.0 (2025-06-04)
 - Improve parser implementation by making it more resilient to syntax errors. It now produces an IllegalNode ast token
+- Improve testing for the parser by adding more checks
 
 ## v2.5.9 (2025-05-29)
 - Added more tests to test `IsInLoop` function

--- a/ast/block_stmt.go
+++ b/ast/block_stmt.go
@@ -28,11 +28,11 @@ func (bs *BlockStmt) String() string {
 		str := s.String()
 
 		if isHTML {
-			out.WriteString(s.String())
+			out.WriteString(str)
 		} else if strings.HasPrefix(str, "@") {
-			out.WriteString(s.String())
+			out.WriteString(str)
 		} else {
-			out.WriteString("{{ " + s.String() + " }}")
+			out.WriteString("{{ " + str + " }}")
 		}
 	}
 

--- a/ast/if_stmt.go
+++ b/ast/if_stmt.go
@@ -8,10 +8,10 @@ import (
 
 type IfStmt struct {
 	BaseNode
-	Condition    Expression    // The truthy condition
-	Consequence  *BlockStmt    // The 'then' block
-	Alternative  *BlockStmt    // The @else block
-	Alternatives []*ElseIfStmt // The @elseif blocks
+	Condition    Expression  // The truthy condition
+	Consequence  *BlockStmt  // The 'then' block
+	Alternative  *BlockStmt  // The @else block
+	Alternatives []Statement // The @elseif blocks
 }
 
 func NewIfStmt(tok token.Token) *IfStmt {
@@ -55,7 +55,9 @@ func (is *IfStmt) Stmts() []Statement {
 	}
 
 	for _, e := range is.Alternatives {
-		res = append(res, e.Stmts()...)
+		if withStmts, ok := e.(NodeWithStatements); ok {
+			res = append(res, withStmts.Stmts()...)
+		}
 	}
 
 	return res

--- a/ast/illegal_node.go
+++ b/ast/illegal_node.go
@@ -14,7 +14,8 @@ func NewIllegalNode(tok token.Token) *IllegalNode {
 	}
 }
 
-func (en *IllegalNode) statementNode() {}
+func (en *IllegalNode) statementNode()  {}
+func (en *IllegalNode) expressionNode() {}
 
 func (en *IllegalNode) String() string {
 	return ""

--- a/ast/illegal_node.go
+++ b/ast/illegal_node.go
@@ -1,0 +1,21 @@
+package ast
+
+import (
+	"github.com/textwire/textwire/v2/token"
+)
+
+type IllegalNode struct {
+	BaseNode
+}
+
+func NewIllegalNode(tok token.Token) *IllegalNode {
+	return &IllegalNode{
+		BaseNode: NewBaseNode(tok),
+	}
+}
+
+func (en *IllegalNode) statementNode() {}
+
+func (en *IllegalNode) String() string {
+	return ""
+}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -133,14 +133,16 @@ func (e *Evaluator) evalIfStmt(node *ast.IfStmt, env *object.Env) object.Object 
 	}
 
 	for _, alt := range node.Alternatives {
-		condition = e.Eval(alt.Condition, env)
+		if ifStmt, ok := alt.(*ast.ElseIfStmt); ok {
+			condition = e.Eval(ifStmt.Condition, env)
 
-		if isError(condition) {
-			return condition
-		}
+			if isError(condition) {
+				return condition
+			}
 
-		if isTruthy(condition) {
-			return e.Eval(alt.Consequence, newEnv)
+			if isTruthy(condition) {
+				return e.Eval(ifStmt.Consequence, newEnv)
+			}
 		}
 	}
 

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -64,7 +64,7 @@ func (e *Evaluator) Eval(node ast.Node, env *object.Env) object.Object {
 		return BREAK
 	case *ast.ContinueStmt:
 		return CONTINUE
-	case *ast.InsertStmt:
+	case *ast.IllegalNode, *ast.InsertStmt:
 		return NIL
 
 	// Expressions

--- a/fail/fail.go
+++ b/fail/fail.go
@@ -26,6 +26,7 @@ const (
 	ErrUndefinedComponent        = "component '%s' is not defined. Check if component exists"
 	ErrUndefinedInsert           = "insert with the name '%s' is not defined in layout. Check if you have a matching reserve statement with the same name"
 	ErrDuplicateInserts          = "duplicate insert statements with the name '%s' found"
+	ErrUseStmtFirstArgStr        = "the first argument of the 'use' statement must be a string, got '%s' instead"
 
 	// Evaluator (interpreter) errors
 	ErrUnknownNodeType         = "unknown node type '%T'"

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -121,12 +121,12 @@ func (l *Lexer) NextToken() token.Token {
 		return l.bracesToken(token.RBRACES, "}}")
 	}
 
-	if !l.isHTML {
-		return l.embeddedCodeToken()
-	}
-
 	if isDirective, _ := l.isDirectiveToken(); isDirective {
 		return l.directiveToken()
+	}
+
+	if !l.isHTML {
+		return l.embeddedCodeToken()
 	}
 
 	return l.newToken(token.HTML, l.readHTML())

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -704,3 +704,18 @@ func TestCommentStatement(t *testing.T) {
 		})
 	})
 }
+
+func TestLexerCanReadIllegalDirectives(t *testing.T) {
+	inp := `@if(false)@dump(@end`
+
+	TokenizeString(t, inp, []token.Token{
+		{Type: token.IF, Literal: "@if", Pos: token.Position{EndCol: 2}},
+		{Type: token.LPAREN, Literal: "(", Pos: token.Position{StartCol: 3, EndCol: 3}},
+		{Type: token.FALSE, Literal: "false", Pos: token.Position{StartCol: 4, EndCol: 8}},
+		{Type: token.RPAREN, Literal: ")", Pos: token.Position{StartCol: 9, EndCol: 9}},
+		{Type: token.DUMP, Literal: "@dump", Pos: token.Position{StartCol: 10, EndCol: 14}},
+		{Type: token.LPAREN, Literal: "(", Pos: token.Position{StartCol: 15, EndCol: 15}},
+		{Type: token.END, Literal: "@end", Pos: token.Position{StartCol: 16, EndCol: 19}},
+		{Type: token.EOF, Literal: "", Pos: token.Position{StartCol: 20, EndCol: 20}},
+	})
+}

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -17,7 +17,7 @@ func TestIsInLoop(t *testing.T) {
 		{doc: `@each(x in users){{x}}@end`, linePos: 0, colPos: 20, expect: true},
 		{doc: `@each(x in users){{x}}@end`, linePos: 0, colPos: 21, expect: true},
 		{doc: `@each(x in users){{x}}@end`, linePos: 0, colPos: 22, expect: false},
-		{doc: `@for(i = 0; i < 10; i++){{x}}@end`, linePos: 0, colPos: 23, expect: false},
+		{doc: `@for(i = 0; i < 10; i++){{x}}@end`, linePos: 0, colPos: 23, expect: false}, // <<<-- TODO: fix this
 		{doc: `@for(i = 0; i < 10; i++){{x}}@end`, linePos: 0, colPos: 24, expect: true},
 		{doc: `@for(i = 0; i < 10; i++){{x}}@end`, linePos: 0, colPos: 25, expect: true},
 		{doc: `@for(i = 0; i < 10; i++){{x}}@end`, linePos: 0, colPos: 26, expect: true},
@@ -29,56 +29,56 @@ func TestIsInLoop(t *testing.T) {
 		{doc: `@for(;;)x@end`, linePos: 0, colPos: 7, expect: false},
 		{
 			doc: `
-		        @each(name in names)
-                {{ loop }}
-		        @end`,
+				        @each(name in names)
+		                {{ loop }}
+				        @end`,
 			linePos: 2,
 			colPos:  23,
 			expect:  true,
 		},
 		{
 			doc: `
-		        @each(name in names)
-                {{ loop }}
-		        @end`,
+				        @each(name in names)
+		                {{ loop }}
+				        @end`,
 			linePos: 2,
 			colPos:  23,
 			expect:  true,
 		},
 		{
 			doc: `
-		          @each(name in names)
-		          {{ loop }}
-		          @end`,
+				          @each(name in names)
+				          {{ loop }}
+				          @end`,
 			linePos: 1,
 			colPos:  30,
 			expect:  false,
 		},
 		{
 			doc: `
-		          @each(name in names)
-		          {{ loop }}
-		          @end`,
+				          @each(name in names)
+				          {{ loop }}
+				          @end`,
 			linePos: 3,
 			colPos:  10,
 			expect:  true,
 		},
 		{
 			doc: `
-		          @each(name in names)
-		              @each(name in names)
-		                  {{ loop }}
-		              @end
-		          @end`,
+				          @each(name in names)
+				              @each(name in names)
+				                  {{ loop }}
+				              @end
+				          @end`,
 			linePos: 3,
 			colPos:  27,
 			expect:  true,
 		},
 		{
 			doc: `
-		          @each(name in names)
-		          {{ loop }}
-		          @end`,
+				          @each(name in names)
+				          {{ loop }}
+				          @end`,
 			linePos: 3,
 			colPos:  15,
 			expect:  false,
@@ -104,20 +104,20 @@ func TestIsInLoop(t *testing.T) {
 		{
 			doc: `@use('~main')
 
-@insert('title', "About Us")
+		@insert('title', "About Us")
 
-@insert('content')
-    @component('~header', {
-        title: "About Us",
-        description: "We have %n potatoes",
-    })
+		@insert('content')
+		    @component('~header', {
+		        title: "About Us",
+		        description: "We have %n potatoes",
+		    })
 
-    @each(name in names)
-        {{ loop }}
-    @end
+		    @each(name in names)
+		        {{ loop }}
+		    @end
 
-    <h2>{{ "Our Team" }}</h2>
-@end`,
+		    <h2>{{ "Our Team" }}</h2>
+		@end`,
 			linePos: 11,
 			colPos:  15,
 			expect:  true,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -393,6 +393,14 @@ func (p *Parser) parseUseStmt() ast.Statement {
 
 	p.nextToken() // skip "("
 
+	if p.curToken.Type != token.STR {
+		p.newError(
+			p.curToken.ErrorLine(),
+			fail.ErrUseStmtFirstArgStr,
+			token.String(p.curToken.Type),
+		)
+	}
+
 	stmt.Name = ast.NewStringLiteral(
 		p.curToken,
 		p.parseAliasPathShortcut("layouts"),

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -725,12 +725,11 @@ func (p *Parser) parseDotExp(left ast.Expression) ast.Expression {
 
 func (p *Parser) parseCallExp(receiver ast.Expression) ast.Expression {
 	ident := ast.NewIdentifier(p.curToken, p.curToken.Literal)
+	exp := ast.NewCallExp(p.curToken, receiver, ident)
 
 	if !p.expectPeek(token.LPAREN) { // move to "("
 		return nil
 	}
-
-	exp := ast.NewCallExp(p.curToken, receiver, ident)
 
 	exp.Arguments = p.parseExpressionList(token.RPAREN)
 	exp.SetEndPosition(p.curToken.Pos)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -724,6 +724,10 @@ func TestErrorHandling(t *testing.T) {
 			"@component('')",
 			fail.New(1, "", "parser", fail.ErrExpectedComponentName),
 		},
+		{
+			"@use(1)",
+			fail.New(1, "", "parser", fail.ErrUseStmtFirstArgStr, token.String(token.INT)),
+		},
 	}
 
 	for _, tc := range tests {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -804,6 +804,7 @@ func TestParseIfElseStatement(t *testing.T) {
 	inp := `@if(true)1@else2@end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
+
 	stmt, ok := stmts[0].(*ast.IfStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not an IfStmt, got %T", stmts[0])
@@ -887,8 +888,8 @@ func TestParseIfElseIfStmt(t *testing.T) {
 	inp := `@if(true)first@elseif(false)second@end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.IfStmt)
 
+	stmt, ok := stmts[0].(*ast.IfStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not an IfStmt, got %T", stmts[0])
 	}
@@ -907,37 +908,37 @@ func TestParseIfElseIfStmt(t *testing.T) {
 	}
 
 	alt := stmt.Alternatives[0]
+	if elseIfStmt, ok := alt.(*ast.ElseIfStmt); ok {
+		if !testBooleanLiteral(t, elseIfStmt.Condition, false) {
+			return
+		}
 
-	testPosition(t, alt.Position(), token.Position{
-		StartCol: 14,
-		EndCol:   33,
-	})
+		if len(elseIfStmt.Consequence.Statements) != 1 {
+			t.Errorf("elseIfStmt.Consequence.Statements does not contain 1 statement, got %d",
+				len(elseIfStmt.Consequence.Statements))
+		}
 
-	if !testBooleanLiteral(t, alt.Condition, false) {
+		cons, ok := elseIfStmt.Consequence.Statements[0].(*ast.HTMLStmt)
+
+		if !ok {
+			t.Fatalf("elseIfStmt.Consequence.Statements[0] is not an HTMLStmt, got %T",
+				elseIfStmt.Consequence.Statements[0])
+		}
+
+		if cons.String() != "second" {
+			t.Errorf("cons.String() is not %q, got %q", "second", cons.String())
+		}
 		return
 	}
 
-	if len(alt.Consequence.Statements) != 1 {
-		t.Errorf("alt.Consequence.Statements does not contain 1 statement, got %d",
-			len(alt.Consequence.Statements))
-	}
-
-	cons, ok := alt.Consequence.Statements[0].(*ast.HTMLStmt)
-
-	if !ok {
-		t.Fatalf("alt.Consequence.Statements[0] is not an HTMLStmt, got %T",
-			alt.Consequence.Statements[0])
-	}
-
-	if cons.String() != "second" {
-		t.Errorf("cons.String() is not %q, got %q", "second", cons.String())
-	}
+	t.Errorf("stmt.Alternatives[0] is not an ElseIfStmt, got %T", alt)
 }
 
 func TestParseIfElseIfElseStatement(t *testing.T) {
 	inp := `@if(true)1@elseif(false)2@else3@end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
+
 	stmt, ok := stmts[0].(*ast.IfStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not an IfStmt, got %T", stmts[0])
@@ -956,26 +957,26 @@ func TestParseIfElseIfElseStatement(t *testing.T) {
 			len(stmt.Alternatives))
 	}
 
-	elseIfAlternative := stmt.Alternatives[0]
+	if elseIfAlt, ok := stmt.Alternatives[0].(*ast.ElseIfStmt); ok {
+		if !testBooleanLiteral(t, elseIfAlt.Condition, false) {
+			return
+		}
 
-	if !testBooleanLiteral(t, elseIfAlternative.Condition, false) {
-		return
-	}
+		if len(elseIfAlt.Consequence.Statements) != 1 {
+			t.Errorf("alternative.Consequence.Statements does not contain 1 statement, got %d",
+				len(elseIfAlt.Consequence.Statements))
+		}
 
-	if len(elseIfAlternative.Consequence.Statements) != 1 {
-		t.Errorf("alternative.Consequence.Statements does not contain 1 statement, got %d",
-			len(elseIfAlternative.Consequence.Statements))
-	}
+		consequence, ok := elseIfAlt.Consequence.Statements[0].(*ast.HTMLStmt)
 
-	consequence, ok := elseIfAlternative.Consequence.Statements[0].(*ast.HTMLStmt)
+		if !ok {
+			t.Fatalf("alternative.Consequence.Statements[0] is not an HTMLStmt, got %T",
+				elseIfAlt.Consequence.Statements[0])
+		}
 
-	if !ok {
-		t.Fatalf("alternative.Consequence.Statements[0] is not an HTMLStmt, got %T",
-			elseIfAlternative.Consequence.Statements[0])
-	}
-
-	if consequence.String() != "2" {
-		t.Errorf("consequence.String() is not %s, got %s", "2", consequence.String())
+		if consequence.String() != "2" {
+			t.Errorf("consequence.String() is not %s, got %s", "2", consequence.String())
+		}
 	}
 }
 
@@ -1008,8 +1009,8 @@ func TestParseAssignStmt(t *testing.T) {
 
 	for _, tc := range tests {
 		stmts := parseStatements(t, tc.inp, defaultParseOpts)
-		stmt, ok := stmts[0].(*ast.AssignStmt)
 
+		stmt, ok := stmts[0].(*ast.AssignStmt)
 		if !ok {
 			t.Fatalf("stmts[0] is not a AssignStmt, got %T", stmts[0])
 		}
@@ -1037,8 +1038,8 @@ func TestParseUseStmt(t *testing.T) {
 	inp := `@use("main")`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.UseStmt)
 
+	stmt, ok := stmts[0].(*ast.UseStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a UseStmt, got %T", stmts[0])
 	}
@@ -1091,7 +1092,6 @@ func TestParseReserveStmt(t *testing.T) {
 	stmts := parseStatements(t, inp, opts)
 
 	stmt, ok := stmts[1].(*ast.ReserveStmt)
-
 	if !ok {
 		t.Fatalf("stmts[0] is not a ReserveStmt, got %T", stmts[0])
 	}
@@ -1117,8 +1117,8 @@ func TestInsertStmt(t *testing.T) {
 		inp := `<h1>@insert("content")<h1>Some content</h1>@end</h1>`
 
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 3, checkErrors: true})
-		stmt, ok := stmts[1].(*ast.InsertStmt)
 
+		stmt, ok := stmts[1].(*ast.InsertStmt)
 		if !ok {
 			t.Fatalf("stmts[1] is not a InsertStmt, got %T", stmts[0])
 		}
@@ -1144,8 +1144,8 @@ func TestInsertStmt(t *testing.T) {
 		inp := `<h1>@insert("content", "Some content")</h1>`
 
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 3, checkErrors: true})
-		stmt, ok := stmts[1].(*ast.InsertStmt)
 
+		stmt, ok := stmts[1].(*ast.InsertStmt)
 		if !ok {
 			t.Fatalf("stmts[1] is not a InsertStmt, got %T", stmts[0])
 		}
@@ -1175,14 +1175,13 @@ func TestParseArray(t *testing.T) {
 	inp := `{{ [11, 234,] }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
 
 	arr, ok := stmt.Expression.(*ast.ArrayLiteral)
-
 	if !ok {
 		t.Fatalf("stmt.Expression is not a ArrayLiteral, got %T", stmt.Expression)
 	}
@@ -1211,14 +1210,13 @@ func TestParseIndexExp(t *testing.T) {
 	inp := `{{ arr[1 + 2][2] }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
 
 	exp, ok := stmt.Expression.(*ast.IndexExp)
-
 	if !ok {
 		t.Fatalf("stmt.Expression is not a IndexExp, got %T", stmt.Expression)
 	}
@@ -1251,14 +1249,13 @@ func TestParsePostfixExp(t *testing.T) {
 
 	for _, tc := range tests {
 		stmts := parseStatements(t, tc.inp, defaultParseOpts)
-		stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+		stmt, ok := stmts[0].(*ast.ExpressionStmt)
 		if !ok {
 			t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 		}
 
 		postfix, ok := stmt.Expression.(*ast.PostfixExp)
-
 		if !ok {
 			t.Fatalf("stmt.Expression is not a PostfixExp, got %T", stmt.Expression)
 		}
@@ -1313,7 +1310,6 @@ func TestParseTwoExpression(t *testing.T) {
 	inp := `{{ 1; 2 }}`
 
 	stmts := parseStatements(t, inp, parseOpts{stmtCount: 2, checkErrors: true})
-
 	if !testIntegerLiteral(t, stmts[0].(*ast.ExpressionStmt).Expression, 1) {
 		return
 	}
@@ -1327,8 +1323,8 @@ func TestParseCallExp(t *testing.T) {
 	inp := `{{ "Serhii Cho".split(" ") }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
@@ -1366,8 +1362,8 @@ func TestParseCallExpWithExpressionList(t *testing.T) {
 	inp := `{{ "nice".replace("n", "") }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
@@ -1393,14 +1389,13 @@ func TestParseCallExpWithEmptyString(t *testing.T) {
 	inp := `{{ "".len() }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
 
 	callExp, ok := stmt.Expression.(*ast.CallExp)
-
 	if !ok {
 		t.Fatalf("stmt.Expression is not a CallExp, got %T", stmt.Expression)
 	}
@@ -1422,8 +1417,8 @@ func TestParseForStmt(t *testing.T) {
     @end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ForStmt)
 
+	stmt, ok := stmts[0].(*ast.ForStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ForStmt, got %T", stmts[0])
 	}
@@ -1468,8 +1463,8 @@ func TestParseForElseStatement(t *testing.T) {
 	inp := `@for(i = 0; i < 0; i++){{ i }}@elseEmpty@end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ForStmt)
 
+	stmt, ok := stmts[0].(*ast.ForStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ForStmt, got %T", stmts[0])
 	}
@@ -1490,8 +1485,8 @@ func TestParseInfiniteForStmt(t *testing.T) {
 	inp := `@for(;;)1@end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ForStmt)
 
+	stmt, ok := stmts[0].(*ast.ForStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ForStmt, got %T", stmts[0])
 	}
@@ -1519,8 +1514,8 @@ func TestParseEachStmt(t *testing.T) {
 	inp := "@each(name in ['anna', 'serhii']){{ name }}@end"
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.EachStmt)
 
+	stmt, ok := stmts[0].(*ast.EachStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a EachStmt, got %T", stmts[0])
 	}
@@ -1556,8 +1551,8 @@ func TestParseEachElseStatement(t *testing.T) {
 	inp := `@each(v in []){{ v }}@elseTest@end`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.EachStmt)
 
+	stmt, ok := stmts[0].(*ast.EachStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a EachStmt, got %T", stmts[0])
 	}
@@ -1574,14 +1569,13 @@ func TestParseObjectStatement(t *testing.T) {
 	inp := `{{ {"father": {name: "John"},} }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
 
 	obj, ok := stmt.Expression.(*ast.ObjectLiteral)
-
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
@@ -1601,7 +1595,6 @@ func TestParseObjectStatement(t *testing.T) {
 	}
 
 	nested, ok := obj.Pairs["father"].(*ast.ObjectLiteral)
-
 	if !ok {
 		t.Fatalf("obj.Pairs['father'] is not a ObjectLiteral, got %T",
 			obj.Pairs["father"])
@@ -1615,14 +1608,13 @@ func TestParseObjectWithShorthandPropertyNotation(t *testing.T) {
 	inp := `{{ { name, age } }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
 
 	obj, ok := stmt.Expression.(*ast.ObjectLiteral)
-
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
@@ -1643,8 +1635,8 @@ func TestParseHTMLStmt(t *testing.T) {
 	inp := "<div><span>Hello</span></div>"
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.HTMLStmt)
 
+	stmt, ok := stmts[0].(*ast.HTMLStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a HTMLStmt, got %T", stmts[0])
 	}
@@ -1661,14 +1653,13 @@ func TestParseDotExp(t *testing.T) {
 	inp := `{{ person.father.name }}`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
 	}
 
 	exp, ok := stmt.Expression.(*ast.DotExp)
-
 	if !ok {
 		t.Fatalf("stmt.Expression is not a DotExp, got %T", stmt.Expression)
 	}
@@ -1695,7 +1686,6 @@ func TestParseDotExp(t *testing.T) {
 	}
 
 	exp, ok = exp.Left.(*ast.DotExp)
-
 	if exp == nil {
 		t.Fatalf("dotExp is nil")
 		return
@@ -1718,8 +1708,8 @@ func TestParseBreakDirective(t *testing.T) {
 	inp := `@break`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.BreakStmt)
 
+	stmt, ok := stmts[0].(*ast.BreakStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a BreakStmt, got %T", stmts[0])
 	}
@@ -1731,8 +1721,8 @@ func TestParseContinueDirective(t *testing.T) {
 	inp := `@continue`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.ContinueStmt)
 
+	stmt, ok := stmts[0].(*ast.ContinueStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a ContinueStmt, got %T", stmts[0])
 	}
@@ -1744,8 +1734,8 @@ func TestParseBreakIfDirective(t *testing.T) {
 	inp := `@breakIf(true)`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.BreakIfStmt)
 
+	stmt, ok := stmts[0].(*ast.BreakIfStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not a BreakIfStmt, got %T", stmts[0])
 	}
@@ -1770,7 +1760,6 @@ func TestParseContinueIfDirective(t *testing.T) {
 	stmts := parseStatements(t, inp, defaultParseOpts)
 
 	stmt, ok := stmts[0].(*ast.ContinueIfStmt)
-
 	if !ok {
 		t.Fatalf("stmts[0] is not a ContinueIfStmt, got %T", stmts[0])
 	}
@@ -1796,7 +1785,6 @@ func TestParseComponentDirective(t *testing.T) {
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 3, checkErrors: true})
 
 		stmt, ok := stmts[1].(*ast.ComponentStmt)
-
 		if !ok {
 			t.Fatalf("stmts[1] is not a ComponentStmt, got %T", stmts[1])
 		}
@@ -1820,7 +1808,6 @@ func TestParseComponentDirective(t *testing.T) {
 		}
 
 		expect := `@component("components/book-card", {"c": card})`
-
 		if stmt.String() != expect {
 			t.Fatalf(`stmt.String() is not '%s', got %s`, expect, stmt.String())
 		}
@@ -1837,7 +1824,6 @@ func TestParseComponentDirective(t *testing.T) {
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 3, checkErrors: true})
 
 		stmt, ok := stmts[1].(*ast.ComponentStmt)
-
 		if !ok {
 			t.Fatalf("stmts[1] is not a ComponentStmt, got %T", stmts[1])
 		}
@@ -1858,14 +1844,12 @@ func TestParseComponentDirective(t *testing.T) {
 		testStringLiteral(t, stmt.Slots[1].Name, "footer")
 
 		expect := "@slot(\"header\")\n<h1>Header</h1>\n@end"
-
 		if stmt.Slots[0].String() != expect {
 			t.Fatalf("stmt.Slots[0].String() is not '%q', got %q", expect,
 				stmt.Slots[0].String())
 		}
 
 		expect = "@slot(\"footer\")\n<footer>Footer</footer>\n@end"
-
 		if stmt.Slots[1].String() != expect {
 			t.Fatalf("stmt.Slots[0].String() is not '%q', got %q", expect,
 				stmt.Slots[1].String())
@@ -1877,7 +1861,6 @@ func TestParseComponentDirective(t *testing.T) {
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 2, checkErrors: true})
 
 		stmt, ok := stmts[0].(*ast.ComponentStmt)
-
 		if !ok {
 			t.Fatalf("stmts[0] is not a ComponentStmt, got %T", stmts[1])
 		}
@@ -1886,19 +1869,16 @@ func TestParseComponentDirective(t *testing.T) {
 		testStringLiteral(t, stmt.Name, "some")
 
 		expect := "@component(\"some\")"
-
 		if stmt.String() != expect {
 			t.Fatalf("stmt.String() is not `%s`, got `%s`", expect, stmt.String())
 		}
 
 		htmlStmt, htmlOk := stmts[1].(*ast.HTMLStmt)
-
 		if !htmlOk {
 			t.Fatalf("stmts[1] is not a HTMLStmt, got %T", stmts[1])
 		}
 
 		expect = "\n <b>Book</b>"
-
 		if htmlStmt.String() != expect {
 			t.Fatalf("htmlStmt.String() is not `%s`, got `%s`", expect, htmlStmt.String())
 		}
@@ -1911,7 +1891,6 @@ func TestParseSlotDirective(t *testing.T) {
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 3, checkErrors: true})
 
 		stmt, ok := stmts[1].(*ast.SlotStmt)
-
 		if !ok {
 			t.Fatalf("stmts[1] is not a SlotStmt, got %T", stmts[1])
 		}
@@ -1937,7 +1916,6 @@ func TestParseSlotDirective(t *testing.T) {
 		stmts := parseStatements(t, inp, parseOpts{stmtCount: 3, checkErrors: true})
 
 		stmt, ok := stmts[1].(*ast.SlotStmt)
-
 		if !ok {
 			t.Fatalf("stmts[1] is not a SlotStmt, got %T", stmts[1])
 		}
@@ -1959,8 +1937,8 @@ func TestParseDumpStmt(t *testing.T) {
 	inp := `@dump("test", 1 + 2, false)`
 
 	stmts := parseStatements(t, inp, defaultParseOpts)
-	stmt, ok := stmts[0].(*ast.DumpStmt)
 
+	stmt, ok := stmts[0].(*ast.DumpStmt)
 	if !ok {
 		t.Fatalf("stmts[0] is not an DumpStmt, got %T", stmts[0])
 	}
@@ -1984,8 +1962,8 @@ func TestIllegalNode(t *testing.T) {
 	inp := "@if(false"
 
 	stmts := parseStatements(t, inp, parseOpts{stmtCount: 1, checkErrors: false})
-	_, ok := stmts[0].(*ast.IllegalNode)
 
+	_, ok := stmts[0].(*ast.IllegalNode)
 	if !ok {
 		t.Errorf("stmts[0] is not an IllegalNode, got %T", stmts[0])
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1969,13 +1969,22 @@ func TestIllegalNode(t *testing.T) {
 	}
 }
 
-// func TestIllegalNodeWithProperNodes(t *testing.T) {
-// 	inp := "@if(false)@dump(@end"
+func TestIllegalNodeWithProperNodes(t *testing.T) {
+	inp := "@if(false)@dump(@end"
 
-// 	stmts := parseStatements(t, inp, parseOpts{stmtCount: 1, checkErrors: false})
-// 	_, ok := stmts[0].(*ast.IfStmt)
+	stmts := parseStatements(t, inp, parseOpts{stmtCount: 1, checkErrors: false})
+	stmt, ok := stmts[0].(*ast.IfStmt)
+	if !ok {
+		t.Errorf("stmts[0] is not an IfStmt, got %T", stmt)
+	}
 
-// 	if !ok {
-// 		t.Errorf("stmts[0] is not an IfStmt, got %T", stmts[0])
-// 	}
-// }
+	dump, ok := stmt.Consequence.Statements[0].(*ast.DumpStmt)
+	if !ok {
+		t.Errorf("stmt.Consequence.Statements[0] is not an DumpStmt, got %T", dump)
+	}
+
+	illegal, ok := dump.Arguments[0].(*ast.IllegalNode)
+	if !ok {
+		t.Errorf("dump.Arguments[0] is not an IllegalNode, got %T", illegal)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1362,6 +1362,33 @@ func TestParseCallExp(t *testing.T) {
 	}
 }
 
+func TestParseCallExpWithExpressionList(t *testing.T) {
+	inp := `{{ "nice".replace("n", "") }}`
+
+	stmts := parseStatements(t, inp, defaultParseOpts)
+	stmt, ok := stmts[0].(*ast.ExpressionStmt)
+
+	if !ok {
+		t.Fatalf("stmts[0] is not a ExpressionStmt, got %T", stmts[0])
+	}
+
+	exp, ok := stmt.Expression.(*ast.CallExp)
+	if !ok {
+		t.Fatalf("stmt.Expression is not a CallExp, got %T", stmt.Expression)
+	}
+
+	testToken(t, exp, token.IDENT)
+
+	testPosition(t, exp.Position(), token.Position{
+		StartCol: 10,
+		EndCol:   25,
+	})
+
+	if len(exp.Arguments) != 2 {
+		t.Fatalf("len(callExp.Arguments) is not 2, got %d", len(exp.Arguments))
+	}
+}
+
 func TestParseCallExpWithEmptyString(t *testing.T) {
 	inp := `{{ "".len() }}`
 


### PR DESCRIPTION
- Improve parser implementation by making it more resilient to syntax errors. It now produces an `IllegalNode` AST token. I'll be able to use it to detect illegal parts in a file and show it with a red squiggly line
- Improve testing for the parser by adding more checks
- Added validation for `@use` statement. Now, if you pass something besides type STR, it will print an error