### PR TITLE
V2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.6.1 (2025-06-10)
 - Improve illegal token detection
-- The body of @each, @for, @if, @insert, @slot and @components statements now can be empty
+- The body of @each, @for, @if, @insert and @slot statements now can be empty
 
 ## v2.6.0 (2025-06-07)
 - Improve parser implementation by making it more resilient to syntax errors. It now produces an IllegalNode ast token. I'll be able to use it to detect illegal parts in a file and show it with a red squiggly line

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -493,10 +493,6 @@ func (p *Parser) parseComponentStmt() ast.Statement {
 		p.nextToken() // move to ")"
 	}
 
-	if p.peekTokenIs(token.END) {
-		p.nextToken() // move to "@end"
-	}
-
 	if p.peekTokenIs(token.SLOT) {
 		p.nextToken() // skip whitespace
 		stmt.Slots = p.parseSlots()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1560,7 +1560,6 @@ func TestParseStmtCanHaveEmptyBody(t *testing.T) {
 		{"@each(name in ['anna', 'serhii'])@end", 36, token.EACH},
 		{"@for(i = 0; i < 10; i++)@end", 27, token.FOR},
 		{"@if(true)@end", 12, token.IF},
-		{"@component('person')@end", 23, token.COMPONENT},
 		{"@insert('content')@end", 21, token.INSERT},
 		{"@component('user')@slot('footer')@end@end", 40, token.COMPONENT},
 	}


### PR DESCRIPTION
- Improve illegal token detection
- The body of `@each`, `@for`, `@if`, `@insert` and `@slot` statements now can be empty