### PR TITLE
V2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## v2.6.4 (2025-06-13)
+- Update completion item structure for LSP to make it treat completion inserts as snippets, not just as text
+
 ## v2.6.3 (2025-06-13)
 - Code refactoring and improving error handling for lsp package
 - For LSP part, textwire now returns full insert text for autocompletion. E.g. instead of `@dump` it will autocomplete to `@dump()` and put the cursor inside `()`

--- a/lsp/completions/completions.go
+++ b/lsp/completions/completions.go
@@ -11,4 +11,11 @@ type Completion struct {
 
 	// Documentation is a full description of the item.
 	Documentation string
+
+	// InsertTextFormat defines whether the insert text in a completion
+	// item should be interpreted as plain text or a snippet.
+	// 1 stands for text format
+	// 2 stands for snippet where you can include `${3:foo}` and just `$1`
+	// special symbols to tell where to place the cursor
+	InsertTextFormat int `json:"insertTextFormat"`
 }

--- a/lsp/completions/directives.go
+++ b/lsp/completions/directives.go
@@ -30,9 +30,10 @@ func GetDirectives(locale lsp.Locale) ([]Completion, error) {
 		}
 
 		completions = append(completions, Completion{
-			Label:         dir,
-			Insert:        insert[1:],
-			Documentation: meta,
+			Label:            dir,
+			Insert:           insert[1:],
+			InsertTextFormat: 2, // 2 = Snippet
+			Documentation:    meta,
 		})
 	}
 


### PR DESCRIPTION
- Update completion item structure for LSP to make it treat completion inserts as snippets, not just as text